### PR TITLE
add documentation

### DIFF
--- a/a_actor.inc
+++ b/a_actor.inc
@@ -10,25 +10,215 @@
 #define _actor_included
 #pragma library actors
 
+/// <summary>Create a static 'actor' in the world. These 'actors' are like NPCs, however they have limited functionality. They do not take up server player slots.</summary>
+/// <param name="modelid">The model ID (skin ID) the actor should have</param>
+/// <param name="X">The X coordinate to create the actor at</param>
+/// <param name="Y">The Y coordinate to create the actor at</param>
+/// <param name="Z">The Z coordinate to create the actor at</param>
+/// <param name="Rotation">The facing angle (rotation) for the actor to have</param>
+/// <seealso name="DestroyActor"/>
+/// <seealso name="SetActorPos"/>
+/// <seealso name="GetActorPos"/>
+/// <seealso name="SetActorFacingAngle"/>
+/// <seealso name="GetActorFacingAngle"/>
+/// <seealso name="SetActorVirtualWorld"/>
+/// <seealso name="GetActorVirtualWorld"/>
+/// <seealso name="ApplyActorAnimation"/>
+/// <seealso name="ClearActorAnimations"/>
+/// <seealso name="GetPlayerCameraTargetActor"/>
+/// <seealso name="IsActorStreamedIn"/>
+/// <seealso name="SetActorHealth"/>
+/// <seealso name="GetActorHealth"/>
+/// <seealso name="SetActorInvulnerable"/>
+/// <seealso name="IsActorInvulnerable"/>
+/// <seealso name="IsValidActor"/>
+/// <seealso name="GetActorPoolSize"/>
+/// <seealso name="GetPlayerTargetActor"/>
+/// <seealso name="OnActorStreamIn"/>
+/// <seealso name="OnActorStreamOut"/>
+/// <seealso name="OnPlayerGiveDamageActor"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   Actors are completely separate from NPCs. They do NOT use player IDs/slots on the server and CANNOT be handled like NPCs.<p/>
+///   Actors are limited to <b><c>1000</c></b> (<b><c>MAX_ACTORS</c></b>).<p/>
+///   Actors can be pushed by vehicles, use a timer to put them back at their positions.<p/>
+///   As of <b>0.3.7 R2</b> actors default to being <a href="http://wiki.sa-mp.com/wiki/SetActorInvulnerable">invulnerable</a>.
+/// </remarks>
+/// <returns>
+///   The created Actor ID (start at <b><c>0</c></b>).<p/>
+///   <b><c>INVALID_ACTOR_ID</c></b> (<b><c>65535</c></b>) If the actor limit (<b><c>1000</c></b>) is reached.
+/// </returns>
 native CreateActor(modelid, Float:X, Float:Y, Float:Z, Float:Rotation);
+
+/// <summary>Destroy an actor which was created with <a href="#CreateActor">CreateActor</a>.</summary>
+/// <param name="actorid">The ID of the actor to destroy. Returned by <a href="#CreateActor">CreateActor</a></param>
+/// <seealso name="CreateActor"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The actor with the ID specified does not exist.
+/// </returns>
 native DestroyActor(actorid);
 
+
+/// <summary>Checks if an actor is streamed in for a player.</summary>
+/// <param name="actorid">The ID of the actor</param>
+/// <param name="forplayerid">The ID of the player</param>
+/// <seealso name="CreateActor"/>
+/// <seealso name="IsPlayerStreamedIn"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the actor is streamed in for the player, or <b><c>0</c></b> if it is not.</returns>
 native IsActorStreamedIn(actorid, forplayerid);
 
+
+/// <summary>Set the virtual world of an actor. Only players in the same world will see the actor.</summary>
+/// <param name="actorid">The ID of the actor (returned by <a href="#CreateActor">CreateActor</a>) to set the virtual world of</param>
+/// <param name="vworld">The virtual world to put the actor ID</param>
+/// <seealso name="GetActorVirtualWorld"/>
+/// <seealso name="CreateActor"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The actor specified does not exist.
+/// </returns>
 native SetActorVirtualWorld(actorid, vworld);
+
+/// <summary>Get the virtual world of an actor.</summary>
+/// <param name="actorid">The ID of the actor to get the virtual world of</param>
+/// <seealso name="SetActorVirtualWorld"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>The virtual world of the actor. By default this is <b><c>0</c></b>. Also returns <b><c>0</c></b> if actor specified does not exist.</returns>
 native GetActorVirtualWorld(actorid);
 
+/// <summary>Apply an animation to an actor.</summary>
+/// <param name="actorid">The ID of the actor to apply the animation to</param>
+/// <param name="animlib">The animation library from which to apply an animation</param>
+/// <param name="animname">The name of the animation to apply, within the specified library</param>
+/// <param name="fDelta">The speed to play the animation (use <b><c>4.1</c></b>)</param>
+/// <param name="loop">If set to <b><c>1</c></b>, the animation will loop. If set to <b><c>0</c></b>, the animation will play once</param>
+/// <param name="lockx">If set to <b><c>0</c></b>, the actor is returned to their old X coordinate once the animation is complete (for animations that move the actor such as walking). <b><c>1</c></b> will not return them to their old position</param>
+/// <param name="locky">Same as above but for the Y axis. Should be kept the same as the previous parameter</param>
+/// <param name="freeze">Setting this to <b><c>1</c></b> will freeze an actor at the end of the animation. <b><c>0</c></b> will not</param>
+/// <param name="time">Timer in milliseconds. For a never-ending loop it should be <b><c>0</c></b></param>
+/// <seealso name="ClearActorAnimations"/>
+/// <remarks>You must preload the animation library for the player the actor will be applying the animation for, and not for the actor. Otherwise, the animation won't be applied to the actor until the function is executed again.</remarks>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+/// <b><c>1</c></b>: The function executed successfully.<p/>
+/// <b><c>0</c></b>: The function failed to execute. The actor specified does not exist.
+/// </returns>
 native ApplyActorAnimation(actorid, animlib[], animname[], Float:fDelta, loop, lockx, locky, freeze, time);
+
+/// <summary>Clear any animations applied to an actor.</summary>
+/// <param name="actorid">The ID of the actor (returned by <a href="#CreateActor">CreateActor</a>) to clear the animations for</param>
+/// <seealso name="ApplyActorAnimation"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The actor specified does not exist.
+/// </returns>
 native ClearActorAnimations(actorid);
 
+
+/// <summary>Set the position of an actor.</summary>
+/// <param name="actorid">The ID of the actor to set the position of. Returned by <a href="#CreateActor">CreateActor</a></param>
+/// <param name="X">The X coordinate to position the actor at</param>
+/// <param name="Y">The Y coordinate to position the actor at</param>
+/// <param name="Z">The Z coordinate to position the actor at</param>
+/// <seealso name="GetActorPos"/>
+/// <seealso name="CreateActor"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>When creating an actor with <a href="#CreateActor">CreateActor</a>, you specify it's position. You do not need to use this function unless you want to change its position later.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The actor specified does not exist.
+/// </returns>
 native SetActorPos(actorid, Float:X, Float:Y, Float:Z);
+
+/// <summary>Get the position of an actor.</summary>
+/// <param name="actorid">The ID of the actor to get the position of. Returned by <a href="# CreateActor">CreateActor</a></param>
+/// <param name="X">A float variable, passed by reference, in which to store the X coordinate of the actor</param>
+/// <param name="Y">A float variable, passed by reference, in which to store the Y coordinate of the actor</param>
+/// <param name="Z">A float variable, passed by reference, in which to store the Z coordinate of the actor</param>
+/// <seealso name="SetActorPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The actor specified does not exist.<p/>
+/// </returns>
 native GetActorPos(actorid, &Float:X, &Float:Y, &Float:Z);
+
+/// <summary>Set the facing angle of an actor.</summary>
+/// <param name="actorid">The ID of the actor to set the facing angle of. Returned by <a href="#CreateActor">CreateActor</a></param>
+/// <param name="ang">The facing angle to set for the actor</param>
+/// <seealso name="GetActorFacingAngle"/>
+/// <seealso name="SetActorPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>Players will see actor's facing angle changed only when it is restreamed to them.</remarks>
+/// <remarks>When creating an actor with <a href="#CreateActor">CreateActor</a>, you specify it's facing angle. You do not need to use this function unless you want to change its facing angle later.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The actor specified does not exist.
+/// </returns>
 native SetActorFacingAngle(actorid, Float:ang);
+
+/// <summary>Get the facing angle of an actor.</summary>
+/// <param name="actorid">The ID of the actor to get the facing angle of. Returned by <a href="#CreateActor">CreateActor</a></param>
+/// <param name="ang">A float variable, passed by reference, in to which the actor's facing angle will be stored</param>
+/// <seealso name="SetActorFacingAngle"/>
+/// <seealso name="GetActorPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The actor specified does not exist.
+/// </returns>
 native GetActorFacingAngle(actorid, &Float:ang);
 
+
+/// <summary>Set the health of an actor.</summary>
+/// <param name="actorid">The ID of the actor to set the health of</param>
+/// <param name="health">The value to set the actors's health to</param>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b> on success.<p/>
+///   <b><c>0</c></b> on failure (i.e. actor is not created).
+/// </returns>
 native SetActorHealth(actorid, Float:health);
+
+/// <summary>Get the health of an actor.</summary>
+/// <param name="actorid">The ID of the actor to get the health of</param>
+/// <param name="health">A float variable, passed by reference, in to which to store the actor's health</param>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b> - success.<p/>
+///   <b><c>0</c></b> - failure (i.e. actor is not created).<p/>
+/// </returns>
 native GetActorHealth(actorid, &Float:health);
+
+/// <summary>Toggle an actor's invulnerability.</summary>
+/// <param name="actorid">The ID of the actor to set invulnerability</param>
+/// <param name="invulnerable"><b><c>false</c></b> to make them vulnerable, <b><c>true</c></b> to make them invulnerable (optional=<b><c>true</c></b>)</param>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>Once set invulnerable, the actor does not call <a href="#OnPlayerGiveDamageActor">OnPlayerGiveDamageActor</a>.</remarks>
+/// <remarks>Players will have actor's invulnerability state changed only when it is restreamed to them.</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Success.<p/>
+///   <b><c>0</c></b> - Failure (i.e. Actor is not created).
+/// </returns>
 native SetActorInvulnerable(actorid, invulnerable = true);
+
+/// <summary>Check if an actor is invulnerable.</summary>
+/// <param name="actorid">The ID of the actor to check</param>
+/// <seealso name="CreateActor"/>
+/// <seealso name="SetActorInvulnerable"/>
+/// <seealso name="SetActorHealth"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the actor is invulnerable, <b><c>0</c></b> otherwise.</returns>
 native IsActorInvulnerable(actorid);
 
+
+/// <summary>Checks if an actor ID is valid.</summary>
+/// <param name="actorid">The ID of the actor to check</param>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the actor is valid, <b><c>0</c></b> if not.</returns>
 native IsValidActor(actorid);

--- a/a_http.inc
+++ b/a_http.inc
@@ -19,6 +19,34 @@
 #define HTTP_ERROR_CONTENT_TOO_BIG		5
 #define HTTP_ERROR_MALFORMED_RESPONSE	6
 
+/// <summary>Sends a threaded HTTP request.</summary>
+/// <param name="index">ID used to differentiate requests that are sent to the same callback (useful for playerids)</param>
+/// <param name="type">The type of request you wish to send</param>
+/// <param name="url">The URL you want to request. (Without 'http://')</param>
+/// <param name="data">Any POST data you want to send with the request</param>
+/// <param name="callback">Name of the callback function you want to use to handle responses to this request</param>
+/// <remarks>This function was added in <b>SA-MP 0.3b</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> on success, <b><c>0</c></b> on failure.</returns>
+/// <remarks>
+///   <b>Request types:</b><p/>
+///   <ul>
+///     <li><b><c>HTTP_GET</c></b></li>
+///     <li><b><c>HTTP_POST</c></b></li>
+///     <li><b><c>HTTP_HEAD</c></b></li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   <b>Response codes:</b><p/>
+///   <ul>
+///     <li><b><c>HTTP_ERROR_BAD_HOST</c></b></li>
+///     <li><b><c>HTTP_ERROR_NO_SOCKET</c></b></li>
+///     <li><b><c>HTTP_ERROR_CANT_CONNECT</c></b></li>
+///     <li><b><c>HTTP_ERROR_CANT_WRITE</c></b></li>
+///     <li><b><c>HTTP_ERROR_CONTENT_TOO_BIG</c></b></li>
+///     <li><b><c>HTTP_ERROR_MALFORMED_RESPONSE</c></b></li>
+///     <li>+ standard HTTP response codes</li>
+///   </ul>
+/// </remarks>
 native HTTP(index, type, url[], data[], callback[]);
 
 // example HTTP callback: public MyHttpResponse(index, response_code, data[]) { ... }

--- a/a_npc.inc
+++ b/a_npc.inc
@@ -24,49 +24,320 @@
 // --------------------------------------------------
 
 // Util
+
+/// <summary>Prints a string to the server console (not in-game chat) and logs (server_log.txt).</summary>
+/// <param name="string">The string to print</param>
+/// <seealso name="printf"/>
 native print(const string[]);
+
+/// <summary>Outputs a formatted string on the console (the server window, not the in-game chat).</summary>
+/// <param name="format">The format string</param>
+/// <param name="">Indefinite number of arguments of any tag</param>
+/// <seealso name="print"/>
+/// <seealso name="format"/>
+/// <remarks>The format string or its output should not exceed 1024 characters. Anything beyond that length can lead to a server to crash.</remarks>
+/// <remarks>This function doesn't support <a href="#strpack">packed</a> strings.</remarks>
+/// <remarks>
+///   <b>Format Specifiers:</b><p/>
+///   <ul>
+///     <li><b><c>%i</c></b> - integer (whole number)</li>
+///     <li><b><c>%d</c></b> - integer (whole number).</li>
+///     <li><b><c>%s</c></b> - string</li>
+///     <li><b><c>%f</c></b> - floating-point number (Float: tag)</li>
+///     <li><b><c>%c</c></b> - ASCII character</li>
+///     <li><b><c>%x</c></b> - hexadecimal number</li>
+///     <li><b><c>%b</c></b> - binary number</li>
+///     <li><b><c>%%</c></b> - literal <b><c>%</c></b></li>
+///     <li><b><c>%q</c></b> - escape a text for SQLite. (Added in <b>0.3.7 R2</b>)</li>
+///   </ul>
+/// </remarks>
+/// <remarks>The values for the placeholders follow in the exact same order as parameters in the call. For example, <b><c>"I am %i years old"</c></b> - the <b><c>%i</c></b> will be replaced with an Integer variable, which is the person's age.</remarks>
+/// <remarks>You may optionally put a number between the <b><c>%</c></b> and the letter of the placeholder code. This number indicates the field width; if the size of the parameter to print at the position of the placeholder is smaller than the field width, the field is expanded with spaces. To cut the number of decimal places beeing shown of a float, you can add <b><c>.&lt;max number&gt;</c></b> between the <b><c>%</c></b> and the <b><c>f</c></b>. (example: <b><c>%.2f</c></b>)</remarks>
 native printf(const format[], {Float,_}:...);
+
+/// <summary>Formats a string to include variables and other strings inside it.</summary>
+/// <param name="output">The string to output the result to</param>
+/// <param name="len">The maximum length output can contain</param>
+/// <param name="format">The format string</param>
+/// <param name="">Indefinite number of arguments of any tag</param>
+/// <seealso name="print"/>
+/// <seealso name="printf"/>
+/// <remarks>This function doesn't support <a href="#strpack">packed strings</a>.</remarks>
+/// <remarks>
+///   <b>Format Specifiers:</b><p/>
+///   <ul>
+///     <li><b><c>%i</c></b> - integer (whole number)</li>
+///     <li><b><c>%d</c></b> - integer (whole number).</li>
+///     <li><b><c>%s</c></b> - string</li>
+///     <li><b><c>%f</c></b> - floating-point number (Float: tag)</li>
+///     <li><b><c>%c</c></b> - ASCII character</li>
+///     <li><b><c>%x</c></b> - hexadecimal number</li>
+///     <li><b><c>%b</c></b> - binary number</li>
+///     <li><b><c>%%</c></b> - literal <b><c>%</c></b></li>
+///     <li><b><c>%q</c></b> - escape a text for SQLite. (Added in <b>0.3.7 R2</b>)</li>
+///   </ul>
+/// </remarks>
+/// <remarks>The values for the placeholders follow in the exact same order as parameters in the call. For example, <b><c>"I am %i years old"</c></b> - the <b><c>%i</c></b> will be replaced with an Integer variable, which is the person's age.</remarks>
+/// <remarks>You may optionally put a number between the <b><c>%</c></b> and the letter of the placeholder code. This number indicates the field width; if the size of the parameter to print at the position of the placeholder is smaller than the field width, the field is expanded with spaces. To cut the number of decimal places beeing shown of a float, you can add <b><c>.&lt;max number&gt;</c></b> between the <b><c>%</c></b> and the <b><c>f</c></b>. (example: <b><c>%.2f</c></b>)</remarks>
 native format(output[], len, const format[], {Float,_}:...);
+
+/// <summary>Sets a 'timer' to call a function after some time. Can be set to repeat.</summary>
+/// <param name="funcname">Name of the function to call as a string. This must be a public function (forwarded). A null string here will crash the server</param>
+/// <param name="interval">Interval in milliseconds</param>
+/// <param name="repeating">Whether the timer should repeat or not</param>
+/// <seealso name="SetTimerEx"/>
+/// <seealso name="KillTimer"/>
+/// <remarks>Timer intervals are not accurate (roughly 25% off). There's a fix available <a href="http://forum.sa-mp.com/showthread.php?t=289675">here</a>. </remarks>
+/// <remarks>Timer IDs are never used twice. You can use <a href="#KillTimer">KillTimer</a> on a timer ID and it won't matter if it's running or not. </remarks>
+/// <remarks>The function that should be called must be public. </remarks>
+/// <remarks>The use of many timers will result in increased memory/cpu usage. </remarks>
+/// <returns>The ID of the timer that was started. Timer IDs start at <b><c>1</c></b>.</returns>
 native SetTimer(funcname[], interval, repeating);
+
+/// <summary>Kills (stops) a running timer.</summary>
+/// <param name="timerid">The ID of the timer to kill (returned by <a href="#SetTimer">SetTimer</a> or <a href="#SetTimerEx">SetTimerEx</a>)</param>
+/// <seealso name="SetTimer"/>
+/// <seealso name="SetTimerEx"/>
+/// <returns>This function always returns <b><c>0</c></b>.</returns>
 native KillTimer(timerid);
+
+/// <summary>Returns the uptime of the actual server (not the SA-MP server) in milliseconds.</summary>
+/// <seealso name="tickcount"/>
+/// <remarks>GetTickCount will cause problems on servers with uptime of over 24 days as GetTickCount will eventually warp past the integer size constraints. However using <a href="https://gist.github.com/ziggi/5d7d8dc42f54531feba7ae924c608e73">this</a> function fixes the problem.</remarks>
+/// <remarks>One common use for GetTickCount is for benchmarking. It can be used to calculate how much time some code takes to execute.</remarks>
+/// <returns>Uptime of the actual server (not the SA-MP server).</returns>
 native GetTickCount();
+
+/// <summary>Get the inversed value of a sine in radians.</summary>
+/// <param name="value">The sine for which to find the angle for</param>
+/// <seealso name="floatsin"/>
+/// <returns>The angle in radians.</returns>
 native Float:asin(Float:value);
+
+/// <summary>Get the inversed value of a cosine in radians.</summary>
+/// <param name="value">The cosine for which to find the angle for</param>
+/// <seealso name="floatcos"/>
+/// <returns>The angle in radians.</returns>
 native Float:acos(Float:value);
+
+/// <summary>Get the inversed value of a tangent in radians.</summary>
+/// <param name="value">The tangent for which to find the angle for</param>
+/// <seealso name="atan2"/>
+/// <seealso name="floattan"/>
+/// <returns>The angle in radians.</returns>
 native Float:atan(Float:value);
+
+/// <summary>Get the multi-valued inversed value of a tangent in radians.</summary>
+/// <param name="x">x size</param>
+/// <param name="y">y size</param>
+/// <seealso name="atan"/>
+/// <seealso name="floattan"/>
+/// <returns>The angle in radians.</returns>
 native Float:atan2(Float:x, Float:y);
 
+
+/// <summary>This will send a player text by the bot, just like using <a href="#SendPlayerMessageToAll">SendPlayerMessageToAll</a>, but this function is to be used inside the NPC scripts.</summary>
+/// <param name="msg">The text to be sent by the NPC</param>
+/// <seealso name="SendCommand"/>
+/// <remarks>This NPC function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native SendChat(msg[]);
+
+/// <summary>This will force the NPC to write a desired command, and this way, getting the effects it would produce.</summary>
+/// <param name="commandtext">The command text to be sent by the NPC</param>
+/// <seealso name="SendChat"/>
+/// <remarks>This NPC function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native SendCommand(commandtext[]);
 
+/// <summary>Get a player's current state.</summary>
+/// <param name="playerid">The ID of the player to get the current state of</param>
+/// <seealso name="GetPlayerSpecialAction"/>
+/// <seealso name="SetPlayerSpecialAction"/>
+/// <seealso name="OnPlayerStateChange"/>
+/// <remarks>
+///   <b>States:</b><p/>
+///   <ul>
+///     <li><b><c>PLAYER_STATE_NONE</c></b> - empty (while initializing)</li>
+///     <li><b><c>PLAYER_STATE_ONFOOT</c></b> - player is on foot</li>
+///     <li><b><c>PLAYER_STATE_DRIVER</c></b> - player is the driver of a vehicle</li>
+///     <li><b><c>PLAYER_STATE_PASSENGER</c></b> - player is passenger of a vehicle</li>
+///     <li><b><c>PLAYER_STATE_WASTED</c></b> - player is dead or on class selection</li>
+///     <li><b><c>PLAYER_STATE_SPAWNED</c></b> - player is spawned</li>
+///     <li><b><c>PLAYER_STATE_SPECTATING</c></b> - player is spectating</li>
+///     <li><b><c>PLAYER_STATE_EXIT_VEHICLE</c></b> - player exits a vehicle</li>
+///     <li><b><c>PLAYER_STATE_ENTER_VEHICLE_DRIVER</c></b> - player enters a vehicle as driver</li>
+///     <li><b><c>PLAYER_STATE_ENTER_VEHICLE_PASSENGER</c></b> - player enters a vehicle as passenger </li>
+///   </ul>
+/// </remarks>
+/// <returns>The player's current state as an integer.</returns>
 native GetPlayerState(playerid);
+
+/// <summary>Get the position of a player, represented by X, Y and Z coordinates.</summary>
+/// <param name="playerid">The ID of the player to get the position of</param>
+/// <param name="x">A float variable in which to store the X coordinate in, passed by reference</param>
+/// <param name="y">A float variable in which to store the Y coordinate in, passed by reference</param>
+/// <param name="z">A float variable in which to store the Z coordinate in, passed by reference</param>
+/// <seealso name="SetPlayerPos"/>
+/// <seealso name="GetVehiclePos"/>
+/// <seealso name="IsPlayerInRangeOfPoint"/>
+/// <seealso name="GetPlayerDistanceFromPoint"/>
+/// <remarks>This function is known to return unreliable values when used in <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a> and <a href="#OnPlayerRequestClass">OnPlayerRequestClass</a>. This is because the player is not spawned.</remarks>
+/// <returns><b><c>true</c></b> on success, <b><c>false</c></b> on failure (i.e. player not connected).</returns>
 native GetPlayerPos(playerid, &Float:x, &Float:y, &Float:z);
+
+/// <summary>This function gets the ID of the vehicle the player is currently in. Note: <b>NOT</b> the model id of the vehicle. See <a href="#GetVehicleModel">GetVehicleModel</a> for that.</summary>
+/// <param name="playerid">The ID of the player in the vehicle that you want to get the ID of</param>
+/// <seealso name="IsPlayerInVehicle"/>
+/// <seealso name="IsPlayerInAnyVehicle"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <seealso name="GetVehicleModel"/>
+/// <returns>ID of the vehicle or <b><c>0</c></b> if not in a vehicle.</returns>
 native GetPlayerVehicleID(playerid);
 native GetPlayerArmedWeapon(playerid);
+
 native GetPlayerHealth(playerid);
 native GetPlayerArmour(playerid);
+
+/// <summary>Retrieves a player's current <a href="http://wiki.sa-mp.com/wiki/SpecialActions">special action</a>.</summary>
+/// <param name="playerid">The ID of the player to get the <a href="http://wiki.sa-mp.com/wiki/SpecialActions">special action</a> of</param>
+/// <seealso name="SetPlayerSpecialAction"/>
+/// <seealso name="GetPlayerState"/>
+/// <returns>The <a href="http://wiki.sa-mp.com/wiki/SpecialActions">special action</a> of the player.</returns>
 native GetPlayerSpecialAction(playerid);
+
+/// <summary>Checks if a player is streamed in for an NPC. Only nearby players are streamed in.</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="IsVehicleStreamedIn"/>
+/// <remarks>This NPC function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the player is streamed in, <b><c>0</c></b> if not.</returns>
 native IsPlayerStreamedIn(playerid);
+
+/// <summary>Checks if a vehicle is streamed in for an NPC. Only nearby vehicles are streamed in.</summary>
+/// <param name="vehicleid">The ID of the vehicle to check</param>
+/// <seealso name="IsPlayerStreamedIn"/>
+/// <remarks>This NPC function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the vehicle is streamed in, <b><c>0</c></b> if not.</returns>
 native IsVehicleStreamedIn(vehicleid);
+
+/// <summary>Check which keys a player is pressing.</summary>
+/// <param name="playerid">The ID of the player to get the keys of</param>
+/// <param name="keys">Bitmask containing the player's key states. <a href="http://wiki.sa-mp.com/wiki/Keys">List of keys</a></param>
+/// <param name="updown">Up/down state</param>
+/// <param name="leftright">Left/right state</param>
+/// <seealso name="OnPlayerKeyStateChange"/>
+/// <remarks>Only the FUNCTION of keys can be detected; not actual keys. For example, it is not possible to detect if a player presses <b>SPACE</b>, but you can detect if they press <b>SPRINT</b> (which can be mapped (assigned/binded) to ANY key (but is space by default)). </remarks>
+/// <remarks>As of update 0.3.7, the keys "A" and "D" are not recognized when in a vehicle. However, keys "W" and "S" can be detected with the "keys" parameter. </remarks>
+/// <returns>The keys are stored in the specified variables.</returns>
 native GetPlayerKeys(playerid, &keys, &updown, &leftright);
+
+/// <summary>Gets the angle a player is facing.</summary>
+/// <param name="playerid">The player you want to get the angle of</param>
+/// <param name="ang">The Float to store the angle in, passed by reference</param>
+/// <remarks>Angles are reversed in GTA:SA; 90 degrees would be East in the real world, but in GTA:SA 90 degrees is in fact West. North and South are still 0/360 and 180. To convert this, simply do <b>360 - angle</b>.</remarks>
+/// <remarks>Angles returned when inside a vehicle is rarely correct. To get the correct facing angle while inside a vehicle, use <a href="#GetVehicleZAngle">GetVehicleZAngle</a>.</remarks>
 native GetPlayerFacingAngle(playerid, &Float:ang);
+
+/// <summary>Get the current location of the NPC.</summary>
+/// <param name="x">A float to save the X coordinate, passed by reference</param>
+/// <param name="y">A float to save the Y coordinate, passed by reference</param>
+/// <param name="z">A float to save the Z coordinate, passed by reference</param>
+/// <seealso name="SetMyPos"/>
+/// <seealso name="GetDistanceFromMeToPoint"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native GetMyPos(&Float:x, &Float:y, &Float:z);
+
+/// <summary>Set the position of the NPC.</summary>
+/// <param name="x">The X coordinate to put the NPC at</param>
+/// <param name="y">The Y coordinate to put the NPC at</param>
+/// <param name="z">The Z coordinate to put the NPC at</param>
+/// <seealso name="GetMyPos"/>
+/// <seealso name="GetDistanceFromMeToPoint"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native SetMyPos(Float:x, Float:y, Float:z);
+
+/// <summary>Get the current facing angle of the NPC.</summary>
+/// <param name="ang">A float to save the angle in, passed by reference</param>
+/// <seealso name="SetMyFacingAngle"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>The facing angle is stored in the specified variable.</returns>
 native GetMyFacingAngle(&Float:ang);
+
+/// <summary>Set the NPC's facing angle.</summary>
+/// <param name="ang">The new NPC's facing angle</param>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>This function does not return any specific values.</returns>
 native SetMyFacingAngle(Float:ang);
 
+
+/// <summary>Get the distance between the NPC and a point.</summary>
+/// <param name="X">The X coordinate of the point</param>
+/// <param name="Y">The Y coordinate of the point</param>
+/// <param name="Z">The Z coordinate of the point</param>
+/// <param name="Distance">A float to save the distance in, passed by reference</param>
+/// <seealso name="GetMyPos"/>
+/// <seealso name="SetMyPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>This function does not return any specific values.</returns>
 native GetDistanceFromMeToPoint(Float:X, Float:Y, Float:Z, &Float:Distance);
+
+/// <summary>Checks if a player is in range of a point. This native function is faster than the PAWN implementation using distance formula.</summary>
+/// <param name="playerid">The ID of the player</param>
+/// <param name="range">The furthest distance the player can be from the point to be in range</param>
+/// <param name="X">The X coordinate of the point to check the range to</param>
+/// <param name="Y">The Y coordinate of the point to check the range to</param>
+/// <param name="Z">The Z coordinate of the point to check the range to</param>
+/// <seealso name="GetPlayerDistanceFromPoint"/>
+/// <seealso name="GetVehicleDistanceFromPoint"/>
+/// <seealso name="GetPlayerPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the player is in range, <b><c>0</c></b> if not.</returns>
 native IsPlayerInRangeOfPoint(playerid, Float:range, Float:X, Float:Y, Float:Z);
 
+/// <summary>Get a player's name.</summary>
+/// <param name="playerid">The ID of the player to get the name of</param>
+/// <param name="name">An array into which to store the name, passed by reference</param>
+/// <param name="len">The length of the string that should be stored. Recommended to be <b><c>MAX_PLAYER_NAME</c></b></param>
+/// <seealso name="SetPlayerName"/>
+/// <seealso name="GetPlayerIp"/>
+/// <seealso name="GetPlayerPing"/>
+/// <seealso name="GetPlayerScore"/>
+/// <seealso name="GetPlayerVersion"/>
+/// <remarks>A player's name can be up to 24 characters long (as of <b>0.3d R2</b>) by using <a href="#SetPlayerName">SetPlayerName</a>. This is defined in <c>a_samp.inc</c> as <b><c>MAX_PLAYER_NAME</c></b>. However, the client can only join with a nickname between 3 and 20 characters, otherwise the connection will be rejected and the player has to quit to choose a valid name.</remarks>
+/// <returns>The length of the player's name. <b><c>0</c></b> if player specified doesn't exist.</returns>
 native GetPlayerName(playerid, const name[], len);
+
+/// <summary>Checks if a player is connected (if an ID is taken by a connected player).</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="IsPlayerAdmin"/>
+/// <seealso name="OnPlayerConnect"/>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <remarks>This function can be omitted in a lot of cases. Many other functions already have some sort of connection check built in.</remarks>
+/// <returns><b><c>1</c></b> if the player is connected, <b><c>0</c></b> if not.</returns>
 native IsPlayerConnected(playerid);
 
 #define PLAYER_RECORDING_TYPE_NONE		0
 #define PLAYER_RECORDING_TYPE_DRIVER	1
 #define PLAYER_RECORDING_TYPE_ONFOOT	2
 
+/// <summary>This will run a .rec file which has to be saved in the npcmodes/recordings folder. These files allow the NPC to follow certain actions. Their actions can be recorded manually. For more information, check the related functions.</summary>
+/// <param name="playbacktype">The type of recording to be loaded</param>
+/// <param name="recordname">The filename to be loaded, without the .rec extension</param>
+/// <seealso name="StopRecordingPlayback"/>
+/// <remarks>This NPC function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native StartRecordingPlayback(playbacktype, recordname[]);
+
+/// <summary>This will stop the current .rec file which is being ran by the NPC, making it stay idle until some other order is given.</summary>
+/// <seealso name="StartRecordingPlayback"/>
+/// <remarks>This NPC function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native StopRecordingPlayback();
+
+/// <summary>This will pause playing back the recording.</summary>
+/// <seealso name="ResumeRecordingPlayback"/>
+/// <remarks>This NPC function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native PauseRecordingPlayback();
+
+/// <summary>This will resume the paused recording.</summary>
+/// <seealso name="PauseRecordingPlayback"/>
+/// <remarks>This NPC function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native ResumeRecordingPlayback();
 
 // --------------------------------------------------
@@ -171,20 +442,89 @@ native ResumeRecordingPlayback();
 // Forwards (Callback declarations)
 // --------------------------------------------------
 
+
+/// <summary>Gets called when a NPC script is loaded.</summary>
+/// <seealso name="OnNPCModeExit"/>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnNPCModeInit();
+
+/// <summary>Gets called when a NPC-script unloaded.</summary>
+/// <seealso name="OnNPCModeInit"/>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnNPCModeExit();
+
+/// <summary>Gets called when a NPC successfully connects to the server.</summary>
+/// <param name="myplayerid">The playerid the NPC has been given</param>
+/// <seealso name="OnNPCDisconnect"/>
+/// <seealso name="OnPlayerConnect"/>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnNPCConnect(myplayerid);
+
+/// <summary>Gets called when the NPC gets disconnected from the server.</summary>
+/// <param name="reason">The reason why the bot has disconnected from the server</param>
+/// <seealso name="OnNPCConnect"/>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <seealso name="OnPlayerConnect"/>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnNPCDisconnect(reason[]);
+
+/// <summary>Gets called when a NPC spawned.</summary>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnNPCSpawn();
+
+/// <summary>Gets called when a NPC enters a vehicle.</summary>
+/// <param name="vehicleid">The vehicleid from the Vehicle the NPC enters</param>
+/// <param name="seatid">The seatid the NPC uses</param>
+/// <seealso name="OnNPCExitVehicle"/>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnNPCEnterVehicle(vehicleid, seatid);
+
+/// <summary>Gets called when a NPC leaves a vehicle.</summary>
+/// <seealso name="OnNPCEnterVehicle"/>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnNPCExitVehicle();
+
+/// <summary>This callback gets called whenever the NPC sees a ClientMessage. This will be everytime a <a href="#SendClientMessageToAll">SendClientMessageToAll</a> function is used and everytime a <a href="#SendClientMessage">SendClientMessage</a> function is sent towards the NPC. This callback won't be called when someone says something. For a version of this with player text, see <a href="#OnPlayerText">OnPlayerText</a>.</summary>
+/// <param name="color">The color the ClientMessage is</param>
+/// <param name="text">The actual message</param>
+/// <seealso name="OnPlayerText"/>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnClientMessage(color, text[]);
+
+/// <summary>Just as the player version of the callback, this callback is called when any player dies.</summary>
+/// <param name="playerid">The player who has died</param>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnPlayerDeath(playerid);
+
+/// <summary>Opposed to the player version of this callback, this callback is called everytime anyone says anything in the chat. This includes any player, any other NPC, or the same NPC himself.</summary>
+/// <param name="playerid">The player who has written something in the chat</param>
+/// <param name="text">The text written by playerid</param>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnPlayerText(playerid, text[]);
+
+/// <summary>This callback is called when a player is streamed in for an NPC. Only nearby players are streamed in.</summary>
+/// <param name="playerid">The ID of the player that is now streamed in for the NPC</param>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnPlayerStreamIn(playerid);
+
+/// <summary>This callback is called when a player is streamed out the NPC.</summary>
+/// <param name="playerid">The player who has been destreamed</param>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnPlayerStreamOut(playerid);
+
+/// <summary>This callback is called when a vehicle is streamed by the NPC. A simpler definition would be when the NPC sees the grey vehicle icon appear on his map.</summary>
+/// <param name="vehicleid">The vehicle that has been streamed</param>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnVehicleStreamIn(vehicleid);
+
+/// <summary>This callback is called when a vehicle is streamed out for an NPC.</summary>
+/// <param name="vehicleid">The vehicle that was streamed out</param>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnVehicleStreamOut(vehicleid);
+
+/// <summary>This callback is called when a recorded file being reproduced with <a href="#StartRecordingPlayback">StartRecordingPlayback</a> has reached to its end.</summary>
+/// <remarks>This NPC callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 forward OnRecordingPlaybackEnd();
 
 // --------------------------------------------------

--- a/a_objects.inc
+++ b/a_objects.inc
@@ -32,7 +32,10 @@
 /// <seealso name="AttachObjectToPlayer"/>
 /// <seealso name="SetObjectMaterialText"/>
 /// <seealso name="SetObjectMaterial"/>
-/// <remarks>Objects that emit light (lampposts, police lights, bollard lights, neons etc.) that have a greater rotation than <b><c>16.26</c></b> degrees (or <b><c>-16.26</c></b>) on either the X or Y axis will stop shining. This effect also applies to light objects attached to other objects, players and vehicles. If a light object is attached to a car and the car is rotated over <b><c>16.26</c></b> degrees (like in a rollover), the object will also stop emitting light. This is a GTA:SA issue and is not caused by a bug in SA-MP.</remarks>
+/// <remarks>
+///   Objects that emit light (lampposts, police lights, bollard lights, neons etc.) that have a greater rotation than <b><c>16.26</c></b> degrees (or <b><c>-16.26</c></b>) on either the X or Y axis will stop shining. This effect also applies to light objects attached to other objects, players and vehicles.
+///   If a light object is attached to a car and the car is rotated over <b><c>16.26</c></b> degrees (like in a rollover), the object will also stop emitting light. This is a GTA:SA issue and is not caused by a bug in SA-MP.
+/// </remarks>
 /// <remarks>In case the light is attached to another object, one fix for this is to set <b>SyncRotation</b> to false in <a href="#AttachObjectToObject">AttachObjectToObject</a>. This will ensure the light stays at <b><c>0</c></b> rotation. This would only really work for objects that consist ONLY of light, so wouldn't work for the police light for example. </remarks>
 /// <remarks>There is a limit of <a href="http://wiki.sa-mp.com/wiki/Limits"><b><c>1000</c></b> objects (<b><c>MAX_OBJECTS</c></b>)</a>. To circumvent this limit, you can use a <a href="http://forum.sa-mp.com/showthread.php?t=102865">streamer</a></remarks>
 /// <returns>The ID of the object that was created, or <b><c>INVALID_OBJECT_ID</c></b> if the object limit (<b><c>MAX_OBJECTS</c></b>) was reached.</returns>

--- a/a_objects.inc
+++ b/a_objects.inc
@@ -12,38 +12,468 @@
 
 // Objects
 
+/// <summary>Creates an object at specified coordinates in the game world.</summary>
+/// <param name="modelid">The model to create</param>
+/// <param name="X">The X coordinate to create the object at</param>
+/// <param name="Y">The Y coordinate to create the object at</param>
+/// <param name="Z">The Z coordinate to create the object at</param>
+/// <param name="rX">The X rotation of the object</param>
+/// <param name="rY">The Y rotation of the object</param>
+/// <param name="rZ">The Z rotation of the object</param>
+/// <param name="DrawDistance">The distance that San Andreas renders objects at. <b><c>0.0</c></b> will cause objects to render at their default distances. <b>Usable since 0.3b, limited to <c>300</c> prior to 0.3x</b> (optional=<b><c>0.0</c></b>)</param>
+/// <seealso name="DestroyObject"/>
+/// <seealso name="IsValidObject"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <seealso name="MoveObject"/>
+/// <seealso name="SetObjectPos"/>
+/// <seealso name="SetObjectRot"/>
+/// <seealso name="GetObjectPos"/>
+/// <seealso name="GetObjectRot"/>
+/// <seealso name="AttachObjectToPlayer"/>
+/// <seealso name="SetObjectMaterialText"/>
+/// <seealso name="SetObjectMaterial"/>
+/// <remarks>Objects that emit light (lampposts, police lights, bollard lights, neons etc.) that have a greater rotation than <b><c>16.26</c></b> degrees (or <b><c>-16.26</c></b>) on either the X or Y axis will stop shining. This effect also applies to light objects attached to other objects, players and vehicles. If a light object is attached to a car and the car is rotated over <b><c>16.26</c></b> degrees (like in a rollover), the object will also stop emitting light. This is a GTA:SA issue and is not caused by a bug in SA-MP.</remarks>
+/// <remarks>In case the light is attached to another object, one fix for this is to set <b>SyncRotation</b> to false in <a href="#AttachObjectToObject">AttachObjectToObject</a>. This will ensure the light stays at <b><c>0</c></b> rotation. This would only really work for objects that consist ONLY of light, so wouldn't work for the police light for example. </remarks>
+/// <remarks>There is a limit of <a href="http://wiki.sa-mp.com/wiki/Limits"><b><c>1000</c></b> objects (<b><c>MAX_OBJECTS</c></b>)</a>. To circumvent this limit, you can use a <a href="http://forum.sa-mp.com/showthread.php?t=102865">streamer</a></remarks>
+/// <returns>The ID of the object that was created, or <b><c>INVALID_OBJECT_ID</c></b> if the object limit (<b><c>MAX_OBJECTS</c></b>) was reached.</returns>
 native CreateObject(modelid, Float:X, Float:Y, Float:Z, Float:rX, Float:rY, Float:rZ, Float:DrawDistance = 0.0);
+
+/// <summary>Attach an object to a vehicle.</summary>
+/// <param name="objectid">The ID of the object to attach to the vehicle. Note that this is an object ID, not a model ID. The object must be CreateObject created first</param>
+/// <param name="vehicleid">The ID of the vehicle to attach the object to</param>
+/// <param name="OffsetX">The X axis offset from the vehicle to attach the object to</param>
+/// <param name="OffsetY">The Y axis offset from the vehicle to attach the object to</param>
+/// <param name="OffsetZ">The Z axis offset from the vehicle to attach the object to</param>
+/// <param name="RotX">The X rotation offset for the object</param>
+/// <param name="RotY">The Y rotation offset for the object</param>
+/// <param name="RotZ">The Z rotation offset for the object</param>
+/// <seealso name="AttachObjectToPlayer"/>
+/// <seealso name="AttachObjectToObject"/>
+/// <seealso name="AttachPlayerObjectToVehicle"/>
+/// <seealso name="CreateObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c</b> and will not work in earlier versions!</remarks>
+/// <remarks>The object must be created first.</remarks>
+/// <remarks>When the vehicle is destroyed or respawned, the attached objects won't be destroyed with it; they will remain stationary at the position the vehicle disappeared and be reattached to the next vehicle to claim the vehicle ID that the objects were attached to.</remarks>
 native AttachObjectToVehicle(objectid, vehicleid, Float:OffsetX, Float:OffsetY, Float:OffsetZ, Float:RotX, Float:RotY, Float:RotZ);
+
+/// <summary>You can use this function to attach objects to other objects. The objects will folow the main object.</summary>
+/// <param name="objectid">The object to attach to another object</param>
+/// <param name="attachtoid">The object to attach the object to</param>
+/// <param name="OffsetX">The distance between the main object and the object in the X direction</param>
+/// <param name="OffsetY">The distance between the main object and the object in the Y direction</param>
+/// <param name="OffsetZ">The distance between the main object and the object in the Z direction</param>
+/// <param name="RotX">The X rotation between the object and the main object</param>
+/// <param name="RotY">The Y rotation between the object and the main object</param>
+/// <param name="RotZ">The Z rotation between the object and the main object</param>
+/// <param name="SyncRotation">If set to <b><c>0</c></b>, objectid's rotation will not change with <paramref name="attachtoid"/>'s (optional=<b><c>1</c></b>)</param>
+/// <seealso name="AttachObjectToPlayer"/>
+/// <seealso name="AttachObjectToVehicle"/>
+/// <seealso name="CreateObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <ul>
+///     <li>Both objects need to be created before attempting to attach them.</li>
+///     <li>There is no player-object version of this function (AttachPlayerObjectToObject), meaning it will not be supported by streamers.</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+/// <b><c>1</c></b>: The function executed successfully.<p/>
+/// <b><c>0</c></b>: The function failed to execute. This means the first object (<paramref name="objectid"/>) does not exist. There are no internal checks to verify that the second object (<paramref name="attachtoid"/>) exists.
+/// </returns>
 native AttachObjectToObject(objectid, attachtoid, Float:OffsetX, Float:OffsetY, Float:OffsetZ, Float:RotX, Float:RotY, Float:RotZ, SyncRotation = 1);
+
+/// <summary>Attach an object to a player.</summary>
+/// <param name="objectid">The ID of the object to attach to the player</param>
+/// <param name="playerid">The ID of the player to attach the object to</param>
+/// <param name="OffsetX">The distance between the player and the object in the X direction</param>
+/// <param name="OffsetY">The distance between the player and the object in the Y direction</param>
+/// <param name="OffsetZ">The distance between the player and the object in the Z direction</param>
+/// <param name="RotX">The X rotation between the object and the player</param>
+/// <param name="RotY">The Y rotation between the object and the player</param>
+/// <param name="RotZ">The Z rotation between the object and the player</param>
+/// <seealso name="AttachObjectToVehicle"/>
+/// <seealso name="AttachObjectToObject"/>
+/// <seealso name="AttachPlayerObjectToPlayer"/>
+/// <seealso name="SetPlayerAttachedObject"/>
+/// <seealso name="CreateObject"/>
+/// <returns>This function always returns <b><c>0</c></b>.</returns>
 native AttachObjectToPlayer(objectid, playerid, Float:OffsetX, Float:OffsetY, Float:OffsetZ, Float:RotX, Float:RotY, Float:RotZ);
+
+
+/// <summary>Change the position of an object.</summary>
+/// <param name="objectid">The ID of the object to set the position of. Returned by <a href="#CreateObject">CreateObject</a></param>
+/// <param name="X">The X coordinate to position the object at</param>
+/// <param name="Y">The Y coordinate to position the object at</param>
+/// <param name="Z">The Z coordinate to position the object at</param>
+/// <seealso name="GetObjectPos"/>
+/// <seealso name="SetObjectRot"/>
+/// <seealso name="GetPlayerObjectPos"/>
+/// <seealso name="CreateObject"/>
+/// <returns>This function always returns <b><c>1</c></b>, even if the object specified does not exist.</returns>
 native SetObjectPos(objectid, Float:X, Float:Y, Float:Z);
+
+/// <summary>Get the position of an object.</summary>
+/// <param name="objectid">The ID of the object to get the position of.</param>
+/// <param name="X">A variable in which to store the X coordinate, passed by reference</param>
+/// <param name="Y">A variable in which to store the Y coordinate, passed by reference</param>
+/// <param name="Z">A variable in which to store the Z coordinate, passed by reference</param>
+/// <seealso name="SetObjectPos"/>
+/// <seealso name="GetObjectRot"/>
+/// <seealso name="SetPlayerObjectPos"/>
+/// <seealso name="CreateObject"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The specified object does not exist.
+/// </returns>
 native GetObjectPos(objectid, &Float:X, &Float:Y, &Float:Z);
+
+/// <summary>Set the rotation of an object on the three axes (X, Y and Z).</summary>
+/// <param name="objectid">The ID of the object to set the rotation of</param>
+/// <param name="RotX">The X rotation</param>
+/// <param name="RotY">The Y rotation</param>
+/// <param name="RotZ">The Z rotation</param>
+/// <seealso name="GetObjectRot"/>
+/// <seealso name="GetObjectPos"/>
+/// <seealso name="CreateObject"/>
+/// <seealso name="SetPlayerObjectRot"/>
+/// <returns>This function always returns <b><c>1</c></b>, even if the object doesn't exist.</returns>
 native SetObjectRot(objectid, Float:RotX, Float:RotY, Float:RotZ);
+
+/// <summary>Use this function to get the objects current rotation. The rotation is saved by reference in three RotX/RotY/RotZ variables.</summary>
+/// <param name="objectid">The objectid of the object you want to get the rotation from</param>
+/// <param name="RotX">The variable to store the X rotation, passed by reference</param>
+/// <param name="RotY">The variable to store the Y rotation, passed by reference</param>
+/// <param name="RotZ">The variable to store the Z rotation, passed by reference</param>
+/// <seealso name="SetObjectRot"/>
+/// <seealso name="SetObjectPos"/>
+/// <seealso name="SetPlayerObjectRot"/>
+/// <seealso name="CreateObject"/>
+/// <returns>The object's rotation is stored in the referenced variables, not in the return value.</returns>
 native GetObjectRot(objectid, &Float:RotX, &Float:RotY, &Float:RotZ);
+
+/// <summary>Get the model ID of an object.</summary>
+/// <param name="objectid">The ID of the object to get the model of</param>
+/// <seealso name="GetPlayerObjectModel"/>
+/// <seealso name="CreateObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>The model ID of the object. <b><c>-1</c></b> if <paramref name="objectid"/> does not exist.</returns>
 native GetObjectModel(objectid);
+
+/// <summary>Disable collisions between players' cameras and the specified object.</summary>
+/// <param name="objectid">The ID of the object to disable camera collisions on</param>
+/// <seealso name="SetObjectsDefaultCameraCol"/>
+/// <seealso name="SetPlayerObjectNoCameraCol"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions! </remarks>
+/// <remarks>This only works outside the map boundaries (past <b><c>-3000</c></b>/<b><c>3000</c></b> units on the x and/or y axis).</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The object specified does not exist.
+/// </returns>
 native SetObjectNoCameraCol(objectid);
+
+/// <summary>Checks if an object with the ID provided exists.</summary>
+/// <param name="objectid">The ID of the object to check the existence of</param>
+/// <seealso name="IsValidPlayerObject"/>
+/// <seealso name="CreateObject"/>
+/// <seealso name="DestroyObject"/>
+/// <remarks>This is to check if an object exists, not if a model is valid.</remarks>
+/// <returns><b><c>1</c></b> if the object exists, <b><c>0</c></b> if not.</returns>
 native IsValidObject(objectid);
+
+/// <summary>Destroys (removes) an object that was created using <a href="#CreateObject">CreateObject</a>.</summary>
+/// <param name="objectid">The ID of the object to destroy. Returned by <a href="#CreateObject">CreateObject</a></param>
+/// <seealso name="CreateObject"/>
+/// <seealso name="IsValidObject"/>
+/// <seealso name="DestroyPlayerObject"/>
 native DestroyObject(objectid);
+
+/// <summary>Move an object to a new position with a set speed. Players/vehicles will 'surf' the object as it moves.</summary>
+/// <param name="objectid">The ID of the object to move</param>
+/// <param name="X">The X coordinate to move the object to</param>
+/// <param name="Y">The Y coordinate to move the object to</param>
+/// <param name="Z">The Z coordinate to move the object to</param>
+/// <param name="Speed">The speed at which to move the object (units per second)</param>
+/// <param name="RotX">The FINAL X rotation (optional=<b><c>-1000.0</c></b>)</param>
+/// <param name="RotY">The FINAL Y rotation (optional=<b><c>-1000.0</c></b>)</param>
+/// <param name="RotZ">The FINAL Z rotation (optional=<b><c>-1000.0</c></b>)</param>
+/// <seealso name="OnObjectMoved"/>
+/// <seealso name="IsObjectMoving"/>
+/// <seealso name="StopObject"/>
+/// <seealso name="MovePlayerObject"/>
+/// <seealso name="SetObjectPos"/>
+/// <seealso name="SetObjectRot"/>
+/// <seealso name="CreateObject"/>
+/// <remarks>This function can be used to make objects rotate smoothly. In order to achieve this however, the object must also be <b>moved</b>. The specified rotation is the rotation the object will have after the movement. Hence the object will not rotate when no movement is applied. For a script example take a look at the ferriswheel.pwn filterscript made by Kye included in the server package (SA-MP 0.3d and above). </remarks>
+/// <remarks>To fully understand the above note, you can (but not limited to) increase the z position by <b><c>(+0.001</c></b>) and then (<b><c>-0.001</c></b>) after moving it again, as not changing the X, Y or Z will not rotate the object. </remarks>
+/// <returns>The time it will take for the object to move in milliseconds.</returns>
 native MoveObject(objectid, Float:X, Float:Y, Float:Z, Float:Speed, Float:RotX = -1000.0, Float:RotY = -1000.0, Float:RotZ = -1000.0);
+
+/// <summary>Stop a moving object after <a href="#MoveObject">MoveObject</a> has been used.</summary>
+/// <param name="objectid">The ID of the object to stop moving</param>
+/// <seealso name="MoveObject"/>
+/// <seealso name="IsObjectMoving"/>
+/// <seealso name="OnObjectMoved"/>
+/// <seealso name="StopPlayerObject"/>
 native StopObject(objectid);
+
+/// <summary>Checks if the given objectid is moving.</summary>
+/// <param name="objectid">The objectid you want to check if is moving</param>
+/// <seealso name="MoveObject"/>
+/// <seealso name="StopObject"/>
+/// <seealso name="OnObjectMoved"/>
+/// <seealso name="IsPlayerObjectMoving"/>
+/// <remarks>This function was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the object is moving, <b><c>0</c></b> if not.</returns>
 native IsObjectMoving(objectid);
+
+/// <summary>Allows a player to edit an object (position and rotation) using their mouse on a GUI (Graphical User Interface).</summary>
+/// <param name="playerid">The ID of the player that should edit the object</param>
+/// <param name="objectid">The ID of the object to be edited by the player</param>
+/// <seealso name="EditPlayerObject"/>
+/// <seealso name="EditAttachedObject"/>
+/// <seealso name="SelectObject"/>
+/// <seealso name="CancelEdit"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>You can move the camera while editing by pressing and holding the <b>spacebar</b> (or <b>W</b> in vehicle) and moving your mouse.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. Success is reported when a non-existent object is specified, but nothing will happen.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player is not connected.
+/// </returns>
 native EditObject(playerid, objectid);
+
+/// <summary>Allows players to edit a player-object (position and rotation) with a GUI and their mouse.</summary>
+/// <param name="playerid">The ID of the player that should edit the object</param>
+/// <param name="objectid">The object to be edited by the player</param>
+/// <seealso name="EditObject"/>
+/// <seealso name="EditAttachedObject"/>
+/// <seealso name="SelectObject"/>
+/// <seealso name="CancelEdit"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>You can move the camera while editing by pressing and holding the <b>spacebar</b> (or <b>W</b> in vehicle) and moving your mouse.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. Player or object not valid.
+/// </returns>
 native EditPlayerObject(playerid, objectid);
+
+/// <summary>Display the cursor and allow the player to select an object. <a href="#OnPlayerSelectObject">OnPlayerSelectObject</a> is called when the player selects an object.</summary>
+/// <param name="playerid">The ID of the player that should be able to select the object</param>
+/// <seealso name="EditObject"/>
+/// <seealso name="EditPlayerObject"/>
+/// <seealso name="EditAttachedObject"/>
+/// <seealso name="CancelEdit"/>
+/// <seealso name="OnPlayerSelectObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native SelectObject(playerid);
+
+/// <summary>Cancel object edition mode for a player.</summary>
+/// <param name="playerid">The ID of the player to cancel edition for</param>
+/// <seealso name="SelectObject"/>
+/// <seealso name="EditObject"/>
+/// <seealso name="EditPlayerObject"/>
+/// <seealso name="EditAttachedObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native CancelEdit(playerid);
+
+/// <summary>Creates an object which will be visible to only one player.</summary>
+/// <param name="playerid">The ID of the player to create the object for</param>
+/// <param name="modelid">The model to create</param>
+/// <param name="X">The X coordinate to create the object at</param>
+/// <param name="Y">The Y coordinate to create the object at</param>
+/// <param name="Z">The Z coordinate to create the object at</param>
+/// <param name="rX">The X rotation of the object</param>
+/// <param name="rY">The Y rotation of the object</param>
+/// <param name="rZ">The Z rotation of the object</param>
+/// <param name="DrawDistance">The distance from which objects will appear to players. <b><c>0.0</c></b> will cause an object to render at its default distance. Leaving this parameter out will cause objects to be rendered at their default distance. <b>The maximum usable distance is <c>300</c> in versions prior to 0.3x</b>, in which drawdistance can be unlimited (optional=<b><c>0.0</c></b>)</param>
+/// <seealso name="CreateObject"/>
+/// <seealso name="IsValidPlayerObject"/>
+/// <seealso name="DestroyPlayerObject"/>
+/// <seealso name="MovePlayerObject"/>
+/// <seealso name="StopPlayerObject"/>
+/// <seealso name="SetPlayerObjectPos"/>
+/// <seealso name="SetPlayerObjectRot"/>
+/// <seealso name="GetPlayerObjectPos"/>
+/// <seealso name="GetPlayerObjectRot"/>
+/// <seealso name="AttachPlayerObjectToPlayer"/>
+/// <seealso name="AttachObjectToPlayer"/>
+/// <remarks>The 'DrawDistance' parameter was added in <b>0.3b</b>. It must be left out in scripts for older versions of SA:MP.</remarks>
+/// <returns>The ID of the object that was created, or <b><c>INVALID_OBJECT_ID</c></b> if the object limit (<b><c>MAX_OBJECTS</c></b>) was reached.</returns>
 native CreatePlayerObject(playerid, modelid, Float:X, Float:Y, Float:Z, Float:rX, Float:rY, Float:rZ, Float:DrawDistance = 0.0);
+
+/// <summary>Attach a player object to a vehicle.</summary>
+/// <param name="playerid">The ID of the player the object was created for</param>
+/// <param name="objectid">The ID of the object to attach to the vehicle</param>
+/// <param name="vehicleid">The ID of the vehicle to attach the object to</param>
+/// <param name="fOffsetX">The X position offset for attachment</param>
+/// <param name="fOffsetY">The Y position offset for attachment</param>
+/// <param name="fOffsetZ">The Z position offset for attachment</param>
+/// <param name="fRotX">The X rotation offset for attachment</param>
+/// <param name="fRotY">The Y rotation offset for attachment</param>
+/// <param name="RotZ">The Z rotation offset for attachment</param>
+/// <seealso name="CreatePlayerObject"/>
+/// <seealso name="AttachPlayerObjectToPlayer"/>
+/// <seealso name="AttachObjectToVehicle"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>You need to create the object before attempting to attach it to a vehicle.</remarks>
 native AttachPlayerObjectToVehicle(playerid, objectid, vehicleid, Float:fOffsetX, Float:fOffsetY, Float:fOffsetZ, Float:fRotX, Float:fRotY, Float:RotZ);
+
+
+/// <summary>Sets the position of a player-object to the specified coordinates.</summary>
+/// <param name="playerid">The ID of the player whose player-object to set the position of</param>
+/// <param name="objectid">The ID of the player-object to set the position of. Returned by <a href="#CreatePlayerObject">CreatePlayerObject</a></param>
+/// <param name="X">The X coordinate to put the object at</param>
+/// <param name="Y">The Y coordinate to put the object at</param>
+/// <param name="Z">The Z coordinate to put the object at</param>
+/// <seealso name="GetPlayerObjectPos"/>
+/// <seealso name="SetPlayerObjectRot"/>
+/// <seealso name="SetObjectPos"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. Player and/or object do not exist.
+/// </returns>
 native SetPlayerObjectPos(playerid, objectid, Float:X, Float:Y, Float:Z);
+
+/// <summary>Get the position of a player object (<a href="#CreatePlayerObject">CreatePlayerObject</a>).</summary>
+/// <param name="playerid">The ID of the player whose player object to get the position of</param>
+/// <param name="objectid">The object's id of which you want the current location</param>
+/// <param name="X">A float variable in which to store the X coordinate, passed by reference</param>
+/// <param name="Y">A float variable in which to store the Y coordinate, passed by reference</param>
+/// <param name="Z">A float variable in which to store the Z coordinate, passed by reference</param>
+/// <seealso name=""/>
+/// <seealso name="SetPlayerObjectPos"/>
+/// <seealso name="GetPlayerObjectRot"/>
+/// <seealso name="GetObjectPos"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player and/or the object don't exist.<p/>
+///   The object's position is stored in the specified variables.
+/// </returns>
 native GetPlayerObjectPos(playerid, objectid, &Float:X, &Float:Y, &Float:Z);
+
+/// <summary>Set the rotation of an object on the X, Y and Z axis.</summary>
+/// <param name="playerid">The ID of the player whose player-object to rotate</param>
+/// <param name="objectid">The ID of the player-object to rotate</param>
+/// <param name="RotX">The X rotation to set</param>
+/// <param name="RotY">The Y rotation to set</param>
+/// <param name="RotZ">The Z rotation to set</param>
+/// <seealso name="GetPlayerObjectRot"/>
+/// <seealso name="SetPlayerObjectPos"/>
+/// <seealso name="SetObjectRot"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <remarks>To smoothly rotate an object, see <a href="#MovePlayerObject">MovePlayerObject</a>.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute.
+/// </returns>
 native SetPlayerObjectRot(playerid, objectid, Float:RotX, Float:RotY, Float:RotZ);
+
+/// <summary>Use this function to get the object's current rotation. The rotation is saved by reference in three RotX/RotY/RotZ variables.</summary>
+/// <param name="playerid">The player you associated this object to</param>
+/// <param name="objectid">The objectid of the object you want to get the rotation from</param>
+/// <param name="RotX">The variable to store the X rotation, passed by reference</param>
+/// <param name="RotY">The variable to store the Y rotation, passed by reference</param>
+/// <param name="RotZ">The variable to store the Z rotation, passed by reference</param>
+/// <seealso name="SetPlayerObjectRot"/>
+/// <seealso name="GetPlayerObjectPos"/>
+/// <seealso name="GetObjectRot"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <returns>The object's rotation is stored in the specified variables.</returns>
 native GetPlayerObjectRot(playerid, objectid, &Float:RotX, &Float:RotY, &Float:RotZ);
+
+/// <summary>Retrieve the model ID of a player-object.</summary>
+/// <param name="playerid">The ID of the player whose player-object to get the model of</param>
+/// <param name="objectid">The ID of the player-object of which to retrieve the model ID</param>
+/// <seealso name="GetObjectModel"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>The model ID of the player object. If the player or object don't exist, it will return <b><c>-1</c></b> or <b><c>0</c></b> if the player or object does not exist.</returns>
 native GetPlayerObjectModel(playerid, objectid);
+
+/// <summary>Toggles a player object camera collision.</summary>
+/// <param name="playerid">The playerID the object belongs to</param>
+/// <param name="objectid">The ID of the object you want to toggle</param>
+/// <seealso name="SetObjectNoCameraCol"/>
+/// <seealso name="SetObjectsDefaultCameraCol"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This only works outside the map boundaries (past <b><c>-3000</c></b>/<b><c>3000</c></b> units on the x and/or y axis).</remarks>
+/// <returns><b><c>1</c></b> regardless of if the object exists or not.</returns>
 native SetPlayerObjectNoCameraCol(playerid, objectid);
+
+/// <summary>Checks if the given object ID is valid for the given player.</summary>
+/// <param name="playerid">The ID of the player whose player-object to validate</param>
+/// <param name="objectid">The ID of the object to validate</param>
+/// <seealso name="IsValidObject"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <seealso name="DestroyPlayerObject"/>
+/// <returns><b><c>1</c></b> if the object exists, <b><c>0</c></b> if not.</returns>
 native IsValidPlayerObject(playerid, objectid);
+
+/// <summary>Destroy a player-object created using <a href="#CreatePlayerObject">CreatePlayerObject</a>.</summary>
+/// <param name="playerid">The ID of the player whose player-object to destroy</param>
+/// <param name="objectid">The ID of the player-object to destroy. Returned by <a href="#CreatePlayerObject">CreatePlayerObject</a></param>
+/// <seealso name="CreatePlayerObject"/>
+/// <seealso name="IsValidPlayerObject"/>
+/// <seealso name="DestroyObject"/>
 native DestroyPlayerObject(playerid, objectid);
+
+/// <summary>Move a player object with a set speed. Also supports rotation. Players/vehicles will surf moving objects.</summary>
+/// <param name="playerid">The ID of the player whose player-object to move</param>
+/// <param name="objectid">The ID of the object to move</param>
+/// <param name="X">The X coordinate to move the object to</param>
+/// <param name="Y">The Y coordinate to move the object to</param>
+/// <param name="Z">The Z coordinate to move the object to</param>
+/// <param name="Speed">The speed at which to move the object</param>
+/// <param name="RotX">The final X rotation (optional=<b><c>-1000.0</c></b>)</param>
+/// <param name="RotY">The final Y rotation (optional=<b><c>-1000.0</c></b>)</param>
+/// <param name="RotZ">The final Z rotation (optional=<b><c>-1000.0</c></b>)</param>
+/// <seealso name="OnPlayerObjectMoved"/>
+/// <seealso name="IsPlayerObjectMoving"/>
+/// <seealso name="StopPlayerObject"/>
+/// <seealso name="MoveObject"/>
+/// <seealso name="SetPlayerObjectPos"/>
+/// <seealso name="SetPlayerObjectRot"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <remarks><b>0.3d R2</b> and older versions do not have the rotational parameters.</remarks>
+/// <returns>The time it will take for the object to move in milliseconds.</returns>
 native MovePlayerObject(playerid, objectid, Float:X, Float:Y, Float:Z, Float:Speed, Float:RotX = -1000.0, Float:RotY = -1000.0, Float:RotZ = -1000.0);
+
+/// <summary>Stop a moving player-object after <a href="#MovePlayerObject">MovePlayerObject</a> has been used.</summary>
+/// <param name="playerid">The ID of the player whose player-object to stop</param>
+/// <param name="objectid">The ID of the player-object to stop</param>
+/// <seealso name="MovePlayerObject"/>
+/// <seealso name="IsPlayerObjectMoving"/>
+/// <seealso name="OnPlayerObjectMoved"/>
+/// <seealso name="StopObject"/>
 native StopPlayerObject(playerid, objectid);
+
+/// <summary>Checks if the given player objectid is moving.</summary>
+/// <param name="playerid">The ID of the player whose player-object is checked</param>
+/// <param name="objectid">The player objectid you want to check if is moving</param>
+/// <seealso name="MovePlayerObject"/>
+/// <seealso name="StopPlayerObject"/>
+/// <seealso name="OnPlayerObjectMoved"/>
+/// <seealso name="IsObjectMoving"/>
+/// <remarks>This function was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the player object is moving, <b><c>0</c></b> if not.</returns>
 native IsPlayerObjectMoving(playerid, objectid);
+
+/// <summary>The same as AttachObjectToPlayer but for objects which were created for player.</summary>
+/// <param name="objectplayer">The id of the player which is linked with the object</param>
+/// <param name="objectid">The objectid you want to attach to the player</param>
+/// <param name="attachplayer">The id of the player you want to attach to the object</param>
+/// <param name="OffsetX">The distance between the player and the object in the X direction</param>
+/// <param name="OffsetY">The distance between the player and the object in the Y direction</param>
+/// <param name="OffsetZ">The distance between the player and the object in the Z direction</param>
+/// <param name="rX">The X rotation</param>
+/// <param name="rY">The Y rotation</param>
+/// <param name="rZ">The Z rotation</param>
+/// <seealso name="SetPlayerAttachedObject"/>
+/// <seealso name="AttachPlayerObjectToVehicle"/>
+/// <seealso name="AttachObjectToPlayer"/>
+/// <seealso name="CreatePlayerObject"/>
+/// <remarks><b>This function was removed in SA-MP 0.3.</b></remarks>
 native AttachPlayerObjectToPlayer(objectplayer, objectid, attachplayer, Float:OffsetX, Float:OffsetY, Float:OffsetZ, Float:rX, Float:rY, Float:rZ);
 
 #define OBJECT_MATERIAL_SIZE_32x32		10
@@ -65,10 +495,138 @@ native AttachPlayerObjectToPlayer(objectplayer, objectid, attachplayer, Float:Of
 #define OBJECT_MATERIAL_TEXT_ALIGN_CENTER	1
 #define OBJECT_MATERIAL_TEXT_ALIGN_RIGHT	2
 
+
+/// <summary>Replace the texture of an object with the texture from another model in the game.</summary>
+/// <param name="objectid">The ID of the object to change the texture of</param>
+/// <param name="materialindex">The material index on the object to change (<b><c>0</c></b> to <b><c>15</c></b>)</param>
+/// <param name="modelid">The modelid on which the replacement texture is located. Use <b><c>0</c></b> for alpha. Use <b><c>-1</c></b> to change the material color without altering the texture</param>
+/// <param name="txdname">The name of the txd file which contains the replacement texture (use <b><c>"none"</c></b> if not required)</param>
+/// <param name="texturename">The name of the texture to use as the replacement (use <b><c>"none"</c></b> if not required)</param>
+/// <param name="materialcolor">The object color to set, as an integer or hex in <b>ARGB</b> color format. Using <b><c>0</c></b> keeps the existing material color (optional=<b><c>0</c></b>)</param>
+/// <seealso name="SetPlayerObjectMaterial"/>
+/// <seealso name="SetObjectMaterialText"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>Vertex lightning of the object will disappear if material color is changed.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute.
+/// </returns>
 native SetObjectMaterial(objectid, materialindex, modelid, txdname[], texturename[], materialcolor=0);
+
+/// <summary>Replace the texture of a player-object with the texture from another model in the game.</summary>
+/// <param name="playerid">The ID of the player the object is associated to</param>
+/// <param name="objectid">The ID of the object to replace the texture of</param>
+/// <param name="materialindex">The material index on the object to change (<b><c>0</c></b> to <b><c>15</c></b>)</param>
+/// <param name="modelid">The modelid on which replacement texture is located. Use <b><c>0</c></b> for alpha. Use <b><c>-1</c></b> to change the material color without altering the existing texture</param>
+/// <param name="txdname">The name of the txd file which contains the replacement texture (use <b><c>"none"</c></b> if not required)</param>
+/// <param name="texturename">The name of the texture to use as the replacement (use <b><c>"none"</c></b> if not required)</param>
+/// <param name="materialcolor">The object color to set (<b>ARGB</b>). Using <b><c>0</c></b> keeps the existing material color (optional=<b><c>0</c></b>)</param>
+/// <seealso name="SetObjectMaterial"/>
+/// <seealso name="SetPlayerObjectMaterialText"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>Vertex lightning of the object will disappear if material color is changed.</remarks>
 native SetPlayerObjectMaterial(playerid, objectid, materialindex, modelid, txdname[], texturename[], materialcolor=0);
 
+
+/// <summary>Replace the texture of an object with text.</summary>
+/// <param name="objectid">The ID of the object to replace the texture of with text</param>
+/// <param name="text">The text to show on the object. (MAX <b>2048</b> characters)</param>
+/// <param name="materialindex">The object's material index to replace with text (optional=<b><c>0</c></b>)</param>
+/// <param name="materialsize">The size of the material (optional=<b><c>OBJECT_MATERIAL_SIZE_256x128</c></b>)</param>
+/// <param name="fontface">The font to use (optional=<b><c>"Arial"</c></b>)</param>
+/// <param name="fontsize">The size of the text (MAX <b>255</b>) (optional=<b><c>24</c></b>)</param>
+/// <param name="bold">Bold text. Set to <b><c>1</c></b> for bold, <b><c>0</c></b> for not (optional=<b><c>1</c></b>)</param>
+/// <param name="fontcolor">The color of the text, in <b>ARGB</b> format (optional=<b><c>-1</c></b>)</param>
+/// <param name="backcolor">The background color, in <b>ARGB</b> format (optional=<b><c>0</c></b>)</param>
+/// <param name="textalignment">The alignment of the text (optional=<b><c>OBJECT_MATERIAL_TEXT_ALIGN_LEFT</c></b>)</param>
+/// <seealso name="SetPlayerObjectMaterialText"/>
+/// <seealso name="SetObjectMaterial"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>Color embedding can be used for multiple colors in the text.</remarks>
+/// <remarks>
+///   <b>Alignment:</b><p/>
+///   <ul>
+///     <li><b><c>OBJECT_MATERIAL_TEXT_ALIGN_LEFT</c></b> 0</li>
+///     <li><b><c>OBJECT_MATERIAL_TEXT_ALIGN_CENTER</c></b> 1</li>
+///     <li><b><c>OBJECT_MATERIAL_TEXT_ALIGN_RIGHT</c></b> 2</li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   <b>Sizes:</b><p/>
+///   <ul>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_32x32</c></b> 10</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_64x32</c></b> 20</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_64x64</c></b> 30</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_128x32</c></b> 40</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_128x64</c></b> 50</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_128x128</c></b> 60</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_256x32</c></b> 70</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_256x64</c></b> 80</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_256x128</c></b> 90</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_256x256</c></b> 100</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_512x64</c></b> 110</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_512x128</c></b> 120</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_512x256</c></b> 130</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_512x512</c></b> 140</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute.
+/// </returns>
 native SetObjectMaterialText(objectid, text[], materialindex = 0, materialsize = OBJECT_MATERIAL_SIZE_256x128, fontface[] = "Arial", fontsize = 24, bold = 1, fontcolor = 0xFFFFFFFF, backcolor = 0, textalignment = 0);
+
+/// <summary>Replace the texture of a player object with text.</summary>
+/// <param name="playerid">The ID of the player whose player object to set the text of</param>
+/// <param name="objectid">The ID of the object on which to place the text</param>
+/// <param name="text">The text to set</param>
+/// <param name="materialindex">The material index to replace with text (optional=<b><c>0</c></b>)</param>
+/// <param name="materialsize">The size of the material (optional=<b><c>OBJECT_MATERIAL_SIZE_256x128</c></b>)</param>
+/// <param name="fontface">The font to use (optional=<b><c>"Arial"</c></b>)</param>
+/// <param name="fontsize">The size of the text (MAX 255) (optional=<b><c>24</c></b>)</param>
+/// <param name="bold">Bold text. Set to <b><c>1</c></b> for bold, <b><c>0</c></b> for not (optional=<b><c>1</c></b>)</param>
+/// <param name="fontcolor">The color of the text (optional=<b><c>-1</c></b>)</param>
+/// <param name="backcolor">The background color (optional=<b><c>0</c></b>)</param>
+/// <param name="textalignment">The alignment of the text (optional=<b><c>OBJECT_MATERIAL_TEXT_ALIGN_LEFT</c></b>)</param>
+/// <seealso name="SetObjectMaterialText"/>
+/// <seealso name="SetPlayerObjectMaterial"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>Color embedding can be used for multiple colors in the text.</remarks>
+/// <remarks>
+///   <b>Alignment:</b><p/>
+///   <ul>
+///     <li><b><c>OBJECT_MATERIAL_TEXT_ALIGN_LEFT</c></b> 0</li>
+///     <li><b><c>OBJECT_MATERIAL_TEXT_ALIGN_CENTER</c></b> 1</li>
+///     <li><b><c>OBJECT_MATERIAL_TEXT_ALIGN_RIGHT</c></b> 2</li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   <b>Sizes:</b><p/>
+///   <ul>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_32x32</c></b> 10</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_64x32</c></b> 20</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_64x64</c></b> 30</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_128x32</c></b> 40</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_128x64</c></b> 50</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_128x128</c></b> 60</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_256x32</c></b> 70</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_256x64</c></b> 80</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_256x128</c></b> 90</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_256x256</c></b> 100</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_512x64</c></b> 110</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_512x128</c></b> 120</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_512x256</c></b> 130</li>
+///     <li><b><c>OBJECT_MATERIAL_SIZE_512x512</c></b> 140</li>
+///   </ul>
+/// </remarks>
 native SetPlayerObjectMaterialText(playerid, objectid, text[], materialindex = 0, materialsize = OBJECT_MATERIAL_SIZE_256x128, fontface[] = "Arial", fontsize = 24, bold = 1, fontcolor = 0xFFFFFFFF, backcolor = 0, textalignment = 0);
 
+
+/// <summary>Allows camera collisions with newly created objects to be disabled by default.</summary>
+/// <param name="disable"><b><c>1</c></b> to disable camera collisions for newly created objects and <b><c>0</c></b> to enable them (enabled by default)</param>
+/// <seealso name="SetObjectNoCameraCol"/>
+/// <seealso name="SetPlayerObjectNoCameraCol"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function only affects the camera collision of objects created AFTER its use - it does not toggle existing objects' camera collisions.</remarks>
+/// <remarks>This only works outside the map boundaries (past <b><c>-3000</c></b>/<b><c>3000</c></b> units on the x and/or y axis).</remarks>
 native SetObjectsDefaultCameraCol(disable);

--- a/a_players.inc
+++ b/a_players.inc
@@ -563,7 +563,7 @@ native GetPlayerState(playerid);
 
 /// <summary>Get the specified player's IP address and store it in a string.</summary>
 /// <param name="playerid">The ID of the player to get the IP address of</param>
-/// <param name="ip">The string to store the player's IP address in, passed by reference</param>
+/// <param name="name">The string to store the player's IP address in, passed by reference</param>
 /// <param name="len">The maximum length of the IP address (recommended 16)</param>
 /// <seealso name="NetStats_GetIpPort"/>
 /// <seealso name="GetPlayerName"/>
@@ -574,7 +574,7 @@ native GetPlayerState(playerid);
 /// <seealso name="OnPlayerDisconnect"/>
 /// <remarks>This function does not work when used in <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a> because the player is already disconnected. It will return an invalid IP (<b><c>255.255.255.255</c></b>). Save players' IPs under <a href="#OnPlayerConnect">OnPlayerConnect</a> if they need to be used under <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a>. </remarks>
 /// <returns><b><c>1</c></b> on success and <b><c>0</c></b> on failure.</returns>
-native GetPlayerIp(playerid, ip[], len);
+native GetPlayerIp(playerid, name[], len);
 
 /// <summary>Get the ping of a player. The ping measures the amount of time it takes for the server to 'ping' the client and for the client to send the message back.</summary>
 /// <param name="playerid">The ID of the player to get the ping of</param>

--- a/a_players.inc
+++ b/a_players.inc
@@ -27,6 +27,7 @@
 #define SPECIAL_ACTION_SMOKE_CIGGY		21
 #define SPECIAL_ACTION_DRINK_WINE		22
 #define SPECIAL_ACTION_DRINK_SPRUNK		23
+#define SPECIAL_ACTION_PISSING			68
 #define SPECIAL_ACTION_CUFFED			24
 #define SPECIAL_ACTION_CARRY			25
 
@@ -56,113 +57,1498 @@
 #define WEAPONSTATE_RELOADING			3
 
 // Player
+
+/// <summary>This function can be used to change the spawn information of a specific player. It allows you to automatically set someone's spawn weapons, their team, skin and spawn position, normally used in case of minigames or automatic-spawn systems. This function is more crash-safe then using <a href="#SetPlayerSkin">SetPlayerSkin</a> in <a href="#OnPlayerSpawn">OnPlayerSpawn</a> and/or <a href="#OnPlayerRequestClass">OnPlayerRequestClass</a>, even though this has been fixed in 0.2.</summary>
+/// <param name="playerid">The PlayerID of who you want to set the spawn information</param>
+/// <param name="team">The Team-ID of the chosen player</param>
+/// <param name="skin">The skin which the player will spawn with</param>
+/// <param name="x">The X-coordinate of the player's spawn position</param>
+/// <param name="y">The Y-coordinate of the player's spawn position</param>
+/// <param name="z">The Z-coordinate of the player's spawn position</param>
+/// <param name="rotation">The direction in which the player needs to be facing after spawning</param>
+/// <param name="weapon1">The first spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon1_ammo">The amount of ammunition for the primary spawnweapon</param>
+/// <param name="weapon2">The second spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon2_ammo">The amount of ammunition for the second spawnweapon</param>
+/// <param name="weapon3">The third spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon3_ammo">The amount of ammunition for the third spawnweapon</param>
+/// <seealso name="SetPlayerSkin"/>
+/// <seealso name="SetPlayerTeam"/>
+/// <seealso name="SpawnPlayer"/>
 native SetSpawnInfo(playerid, team, skin, Float:x, Float:y, Float:z, Float:rotation, weapon1, weapon1_ammo, weapon2, weapon2_ammo, weapon3, weapon3_ammo);
+
+/// <summary>(Re)Spawns a player.</summary>
+/// <param name="playerid">The ID of the player to spawn</param>
+/// <seealso name="SetSpawnInfo"/>
+/// <seealso name="AddPlayerClass"/>
+/// <seealso name="OnPlayerSpawn"/>
+/// <remarks>Kills the player if they are in a vehicle and then they spawn with a bottle in their hand.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native SpawnPlayer(playerid);
 
 // Player info
+
+/// <summary>Set a player's position.</summary>
+/// <param name="playerid">The ID of the player to set the position of</param>
+/// <param name="x">The X coordinate to position the player at</param>
+/// <param name="y">The Y coordinate to position the player at</param>
+/// <param name="z">The Z coordinate to position the player at</param>
+/// <seealso name="SetPlayerPosFindZ"/>
+/// <seealso name="SetPlayerFacingAngle"/>
+/// <seealso name="GetPlayerPos"/>
+/// <seealso name="SetVehiclePos"/>
+/// <seealso name="GetVehiclePos"/>
+/// <remarks>Using this function on a player in a vehicle will instantly remove them from the vehicle. Useful for quickly ejecting players.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.
+/// </returns>
 native SetPlayerPos(playerid, Float:x, Float:y, Float:z);
+
+/// <summary>This sets the players position then adjusts the players z-coordinate to the nearest solid ground under the position.</summary>
+/// <param name="playerid">The ID of the player to set the position of</param>
+/// <param name="x">The X coordinate to position the player at</param>
+/// <param name="y">The X coordinate to position the player at</param>
+/// <param name="z">The Z coordinate to position the player at</param>
+/// <seealso name="SetPlayerPos"/>
+/// <seealso name="OnPlayerClickMap"/>
+/// <remarks>This function does not work if the new coordinates are far away from where the player currently is. The Z height will be <b><c>0</c></b>, which will likely put them underground. It is highly recommended that the <a href="http://forum.sa-mp.com/showthread.php?t=275492">MapAndreas plugin</a> be used instead.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.
+/// </returns>
 native SetPlayerPosFindZ(playerid, Float:x, Float:y, Float:z);
+
+/// <summary>Get the position of a player, represented by X, Y and Z coordinates.</summary>
+/// <param name="playerid">The ID of the player to get the position of</param>
+/// <param name="x">A float variable in which to store the X coordinate in, passed by reference</param>
+/// <param name="y">A float variable in which to store the Y coordinate in, passed by reference</param>
+/// <param name="z">A float variable in which to store the Z coordinate in, passed by reference</param>
+/// <seealso name="SetPlayerPos"/>
+/// <seealso name="GetVehiclePos"/>
+/// <seealso name="IsPlayerInRangeOfPoint"/>
+/// <seealso name="GetPlayerDistanceFromPoint"/>
+/// <remarks>This function is known to return unreliable values when used in <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a> and <a href="#OnPlayerRequestClass">OnPlayerRequestClass</a>. This is because the player is not spawned.</remarks>
+/// <returns><b><c>true</c></b> on success, <b><c>false</c></b> on failure (i.e. player not connected).</returns>
 native GetPlayerPos(playerid, &Float:x, &Float:y, &Float:z);
+
+/// <summary>Set a player's facing angle (Z rotation).</summary>
+/// <param name="playerid">The ID of the player to set the facing angle of</param>
+/// <param name="ang">The angle the player should face</param>
+/// <seealso name="GetPlayerFacingAngle"/>
+/// <seealso name="SetPlayerPos"/>
+/// <remarks>Angles are reversed in GTA:SA; 90 degrees would be East in the real world, but in GTA:SA 90 degrees is in fact West. North and South are still 0/360 and 180. To convert this, simply do <b>360 - angle</b>.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.
+/// </returns>
 native SetPlayerFacingAngle(playerid,Float:ang);
+
+/// <summary>Gets the angle a player is facing.</summary>
+/// <param name="playerid">The player you want to get the angle of</param>
+/// <param name="ang">The Float to store the angle in, passed by reference</param>
+/// <seealso name="GetVehicleZAngle"/>
+/// <seealso name="SetPlayerFacingAngle"/>
+/// <remarks>Angles are reversed in GTA:SA; 90 degrees would be East in the real world, but in GTA:SA 90 degrees is in fact West. North and South are still 0/360 and 180. To convert this, simply do <b>360 - angle</b>.</remarks>
+/// <remarks>Angles returned when inside a vehicle is rarely correct. To get the correct facing angle while inside a vehicle, use <a href="#GetVehicleZAngle">GetVehicleZAngle</a>.</remarks>
 native GetPlayerFacingAngle(playerid,&Float:ang);
+
+/// <summary>Checks if a player is in range of a point. This native function is faster than the PAWN implementation using distance formula.</summary>
+/// <param name="playerid">The ID of the player</param>
+/// <param name="range">The furthest distance the player can be from the point to be in range</param>
+/// <param name="x">The X coordinate of the point to check the range to</param>
+/// <param name="y">The Y coordinate of the point to check the range to</param>
+/// <param name="z">The Z coordinate of the point to check the range to</param>
+/// <seealso name="GetPlayerDistanceFromPoint"/>
+/// <seealso name="GetVehicleDistanceFromPoint"/>
+/// <seealso name="GetPlayerPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the player is in range, <b><c>0</c></b> if not.</returns>
 native IsPlayerInRangeOfPoint(playerid, Float:range, Float:x, Float:y, Float:z);
+
+/// <summary>Calculate the distance between a player and a map coordinate.</summary>
+/// <param name="playerid">The ID of the player to calculate the distance from</param>
+/// <param name="X">The X map coordinate</param>
+/// <param name="Y">The Y map coordinate</param>
+/// <param name="Z">The Z map coordinate</param>
+/// <seealso name="IsPlayerInRangeOfPoint"/>
+/// <seealso name="GetVehicleDistanceFromPoint"/>
+/// <seealso name="GetPlayerPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c R3</b> and will not work in earlier versions!</remarks>
+/// <returns>The distance between the player and the point as a float.</returns>
 native Float:GetPlayerDistanceFromPoint(playerid, Float:X, Float:Y, Float:Z);
+
+/// <summary>Checks if a player is streamed in another player's client.</summary>
+/// <param name="playerid">The ID of the player to check is streamed in</param>
+/// <param name="forplayerid">The ID of the player to check if playerid is streamed in for</param>
+/// <seealso name="IsActorStreamedIn"/>
+/// <seealso name="IsVehicleStreamedIn"/>
+/// <seealso name="OnPlayerStreamIn"/>
+/// <seealso name="OnPlayerStreamOut"/>
+/// <seealso name="OnVehicleStreamIn"/>
+/// <seealso name="OnVehicleStreamOut"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>Players aren't streamed in on their own client, so if playerid is the same as forplayerid it will return false!</remarks>
+/// <remarks>Players stream out if they are more than <b><c>150</c></b> meters away (see <c>server.cfg</c> - <c>stream_distance</c>)</remarks>
+/// <returns><b><c>1</c></b> if the player is streamed in, <b><c>0</c></b> if not.</returns>
 native IsPlayerStreamedIn(playerid, forplayerid);
+
+/// <summary>Set a player's interior. A list of currently known interiors and their positions can be found <a href="http://wiki.sa-mp.com/wiki/InteriorIDs">here</a>.</summary>
+/// <param name="playerid">The ID of the player to set the interior of</param>
+/// <param name="interiorid">The <a href="http://wiki.sa-mp.com/wiki/InteriorIDs">interior ID</a> to set the player in</param>
+/// <seealso name="GetPlayerInterior"/>
+/// <seealso name="LinkVehicleToInterior"/>
+/// <seealso name="OnPlayerInteriorChange"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native SetPlayerInterior(playerid,interiorid);
+
+/// <summary>Retrieves the player's current interior. A list of currently known interiors with their positions can be found on <a href="http://wiki.sa-mp.com/wiki/InteriorIDs">this</a> page.</summary>
+/// <param name="playerid">The player to get the interior ID of</param>
+/// <seealso name="SetPlayerInterior"/>
+/// <seealso name="GetPlayerVirtualWorld"/>
+/// <remarks>Always returns <b><c>0</c></b> for NPCs.</remarks>
+/// <returns>The interior ID the player is currently in.</returns>
 native GetPlayerInterior(playerid);
+
+
+/// <summary>Set the health of a player.</summary>
+/// <param name="playerid">The ID of the player to set the health of</param>
+/// <param name="health">The value to set the player's health to. Max health that can be displayed in the HUD is <b><c>100</c></b>, though higher values are valid</param>
+/// <seealso name="GetPlayerHealth"/>
+/// <seealso name="GetPlayerArmour"/>
+/// <seealso name="SetPlayerArmour"/>
+/// <remarks>Health is obtained rounded to integers: set <b><c>50.15</c></b>, but get <b><c>50.0</c></b></remarks>
+/// <remarks>If a player's health is set to <b><c>0</c></b> or a minus value, they will die instantly.</remarks>
+/// <remarks>If a player's health is below <b><c>10</c></b> or above <b><c>98303</c></b>, their health bar will flash. </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.
+/// </returns>
 native SetPlayerHealth(playerid, Float:health);
+
+/// <summary>The function GetPlayerHealth allows you to retrieve the health of a player. Useful for cheat detection, among other things.</summary>
+/// <param name="playerid">The ID of the player</param>
+/// <param name="health">Float to store health, passed by reference</param>
+/// <seealso name="SetPlayerHealth"/>
+/// <seealso name="GetVehicleHealth"/>
+/// <seealso name="GetPlayerArmour"/>
+/// <remarks>
+///   Even though the health can be set to near infinite values on the server side, the individual clients will only report values up to <b><c>255</c></b>. Anything higher will wrap around; <b><c>256</c></b> becomes <b><c>0</c></b>, <b><c>257</c></b> becomes <b><c>1</c></b>, etc.<p/>
+///   Health is obtained rounded to integers: set <b><c>50.15</c></b>, but get <b><c>50.0</c></b>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b> - success.<p/>
+///   <b><c>0</c></b> - failure (i.e. player not connected).<p/>
+/// </returns>
 native GetPlayerHealth(playerid, &Float:health);
+
+/// <summary>Set a player's armor level.</summary>
+/// <param name="playerid">The ID of the player to set the armour of</param>
+/// <param name="armour">The amount of armour to set, as a percentage (float). Values larger than <b><c>100</c></b> are valid, but won't be displayed in the HUD's armour bar</param>
+/// <seealso name="GetPlayerArmour"/>
+/// <seealso name="SetPlayerHealth"/>
+/// <seealso name="GetPlayerHealth"/>
+/// <remarks>Armour is obtained rounded to integers: set <b><c>50.15</c></b>, but get <b><c>50.0</c></b></remarks>
+/// <remarks>The function's name is armour, not armor (Americanized). This is inconsistent with the rest of SA-MP, so remember that.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.
+/// </returns>
 native SetPlayerArmour(playerid, Float:armour);
+
+/// <summary>This function stores the armour of a player into a variable.</summary>
+/// <param name="playerid">The ID of the player that you want to get the armour of</param>
+/// <param name="armour">The float to to store the armour in, passed by reference</param>
+/// <seealso name="SetPlayerArmour"/>
+/// <seealso name="GetPlayerHealth"/>
+/// <seealso name="GetVehicleHealth"/>
+/// <remarks>Even though the armour can be set to near infinite values on the server side, the individual clients will only report values up to <b><c>255</c></b>. Anything higher will wrap around; <b><c>256</c></b> becomes <b><c>0</c></b>, <b><c>257</c></b> becomes <b><c>1</c></b>, etc. </remarks>
+/// <remarks>Armour is obtained rounded to integers: set <b><c>50.15</c></b>, but get <b><c>50.0</c></b> </remarks>
+/// <remarks>The function's name is armour, not armor (Americanized). This is inconsistent with the rest of SA-MP, so remember that.</remarks>
+/// <returns>
+///   <b><c>1</c></b> - success.<p/>
+///   <b><c>0</c></b> - failure (i.e. player not connected).<p/>
+/// </returns>
 native GetPlayerArmour(playerid, &Float:armour);
+
+/// <summary>Set the ammo of a player's weapon.</summary>
+/// <param name="playerid">The ID of the player to set the weapon ammo of</param>
+/// <param name="weaponslot">The ID of the <a href="http://wiki.sa-mp.com/wiki/Weapons">weapon slot</a> to set the ammo of.</param>
+/// <param name="ammo">The amount of ammo to set</param>
+/// <seealso name="GetPlayerAmmo"/>
+/// <seealso name="GivePlayerWeapon"/>
+/// <seealso name="SetPlayerArmedWeapon"/>
+/// <remarks>Set the ammo to <b><c>0</c></b> to remove a weapon from a player's inventory. Note that the weapon will still show up in <a href="#GetPlayerWeaponData">GetPlayerWeaponData</a>, albeit with <b><c>0</c></b> ammo.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. Success is also returned when the weapon slot specified is invalid (not 0-12).<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player isn't connected.<p/>
+/// </returns>
 native SetPlayerAmmo(playerid, weaponslot, ammo);
+
+/// <summary>Gets the amount of ammo in a player's current weapon.</summary>
+/// <param name="playerid">The ID of the player whose ammo to get</param>
+/// <seealso name="SetPlayerAmmo"/>
+/// <seealso name="GetPlayerWeaponData"/>
+/// <remarks>The ammo can hold 16-bit values, therefore values over <b><c>32767</c></b> will return erroneous values.</remarks>
+/// <returns>The amount of ammo in the player's current weapon.</returns>
 native GetPlayerAmmo(playerid);
+
+/// <summary>Check the state of a player's weapon.</summary>
+/// <param name="playerid">The ID of the player to obtain the weapon state of</param>
+/// <seealso name="GivePlayerWeapon"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Weapon states:</b><p/>
+///   <ul>
+///     <li><b><c>WEAPONSTATE_UNKNOWN</c></b> - unknown (Set when in a vehicle)</li>
+///     <li><b><c>WEAPONSTATE_NO_BULLETS</c></b> - The weapon has no remaining ammo</li>
+///     <li><b><c>WEAPONSTATE_LAST_BULLET</c></b> - the weapon has one remaining bullet</li>
+///     <li><b><c>WEAPONSTATE_MORE_BULLETS</c></b> - the weapon has multiple bullets</li>
+///     <li><b><c>WEAPONSTATE_RELOADING</c></b> - the player is reloading their weapon </li>
+///   </ul>
+/// </remarks>
+/// <returns>The state of the player's weapon. <b><c>0</c></b> if player specified does not exist.</returns>
 native GetPlayerWeaponState(playerid);
+
+/// <summary>Check who a player is aiming at.</summary>
+/// <param name="playerid">The ID of the player to get the target of</param>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <seealso name="OnPlayerGiveDamage"/>
+/// <seealso name="OnPlayerTakeDamage"/>
+/// <remarks>This function was added in <b>SA-MP 0.3d</b> and will not work in earlier versions! </remarks>
+/// <remarks>Does not work for joypads/controllers, and after a certain distance. </remarks>
+/// <remarks>Does not work for the sniper rifle, as it doesn't lock on to anything and as such can't and won't return a player. </remarks>
+/// <returns>The ID of the target player, or <b><c>INVALID_PLAYER_ID</c></b> if none.</returns>
 native GetPlayerTargetPlayer(playerid);
+
+/// <summary>Gets id of an actor which is aimed by certain player.</summary>
+/// <param name="playerid">The ID of the player to get the target of</param>
+/// <seealso name="GetPlayerCameraTargetActor"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <seealso name="OnPlayerGiveDamageActor"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>Does not work for joypads/controllers, and after a certain distance. </remarks>
+/// <remarks>Does not work for the sniper rifle, as it doesn't lock on to anything and as such can't and won't return a player. </remarks>
+/// <returns>The ID of the targeted actor, or <b><c>INVALID_ACTOR_ID</c></b> if none.</returns>
 native GetPlayerTargetActor(playerid);
+
+/// <summary>Set the team of a player.</summary>
+/// <param name="playerid">The ID of the player you want to set the team of</param>
+/// <param name="teamid">The team to put the player in. Use <b><c>NO_TEAM</c></b> to remove the player from any team</param>
+/// <seealso name="GetPlayerTeam"/>
+/// <seealso name="SetTeamCount"/>
+/// <seealso name="EnableVehicleFriendlyFire"/>
+/// <remarks>Players can not damage/kill players on the same team unless they use a knife to slit their throat. As of <b>SA-MP 0.3x</b>, players are also unable to damage vehicles driven by a player from the same team. This can be enabled with <a href="#EnableVehicleFriendlyFire">EnableVehicleFriendlyFire</a>.</remarks>
+/// <remarks><b><c>255</c></b> (or <b><c>NO_TEAM</c></b>) is the default team to be able to shoot other players, not <b><c>0</c></b>.</remarks>
 native SetPlayerTeam(playerid, teamid);
+
+/// <summary>Get the ID of the team the player is on.</summary>
+/// <param name="playerid">The ID of the player to get the team of</param>
+/// <seealso name="SetPlayerTeam"/>
+/// <seealso name="SetTeamCount"/>
+/// <returns>
+///   <b><c>0-254</c></b>: The player's team. (<b><c>0</c></b> is a valid team).<p/>
+///   <b><c>255</c></b>: Defined as <b><c>NO_TEAM</c></b>. The player is not on any team.<p/>
+///   <b><c>-1</c></b>: The function failed to execute. Player is not connected.
+/// </returns>
 native GetPlayerTeam(playerid);
+
+/// <summary>Set a player's score. Players' scores are shown in the scoreboard (shown by holding the TAB key).</summary>
+/// <param name="playerid">The ID of the player to set the score of</param>
+/// <param name="score">The value to set the player's score to</param>
+/// <seealso name="GetPlayerScore"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.
+/// </returns>
 native SetPlayerScore(playerid,score);
+
+/// <summary>This function returns a player's score as it was set using <a href="#SetPlayerScore">SetPlayerScore</a>.</summary>
+/// <param name="playerid">The player to get the score of</param>
+/// <seealso name="SetPlayerScore"/>
+/// <seealso name="GetPlayerPing"/>
+/// <returns>The player's score.</returns>
 native GetPlayerScore(playerid);
+
+/// <summary>Checks the player's level of drunkenness. If the level is less than <b><c>2000</c></b>, the player is sober. The player's level of drunkness goes down slowly automatically (1 level per frame) but will always reach <b><c>2000</c></b> at the end (in <b>0.3b</b> it will stop at <b><c>0</c></b>). The higher drunkenness levels affect the player's camera, and the car driving handling. The level of drunkenness increases when the player drinks from a bottle (You can use <a href="#SetPlayerSpecialAction">SetPlayerSpecialAction</a> to give them bottles).</summary>
+/// <param name="playerid">The player you want to check the drunkenness level of</param>
+/// <seealso name="SetPlayerDrunkLevel"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>An integer with the level of drunkenness of the player.</returns>
 native GetPlayerDrunkLevel(playerid);
+
+/// <summary>Sets the drunk level of a player which makes the player's camera sway and vehicles hard to control.</summary>
+/// <param name="playerid">The ID of the player to set the drunkenness of</param>
+/// <param name="level">The level of drunkenness to set</param>
+/// <seealso name="GetPlayerDrunkLevel"/>
+/// <remarks>
+///   Players' drunk level will automatically decrease over time, based on their FPS (players with <b><c>50</c></b> FPS will lose <b><c>50</c></b> 'levels' per second. This is useful for determining a player's FPS!).<p/>
+///   In <b>0.3a</b> the drunk level will decrement and stop at <b><c>2000</c></b>. In <b>0.3b+</b> the drunk level decrements to <b><c>0</c></b>)<p/>
+///   Levels over <b><c>2000</c></b> make the player drunk (camera swaying and vehicles difficult to control).<p/>
+///   Max drunk level is <b><c>50000</c></b>.<p/>
+///   While the drunk level is above <b><c>5000</c></b>, the player's HUD (radar etc.) will be hidden.
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native SetPlayerDrunkLevel(playerid, level);
+
+/// <summary>Set the colour of a player's nametag and marker (radar blip).</summary>
+/// <param name="playerid">The ID of the player whose color to set</param>
+/// <param name="color">The color to set. Supports alpha values (<b>RGBA</b>)</param>
+/// <seealso name="SetPlayerMarkerForPlayer"/>
+/// <seealso name="GetPlayerColor"/>
+/// <seealso name="ChangeVehicleColor"/>
+/// <remarks>This function will change player's color for everyone, even if player's color was changed with <a href="#SetPlayerMarkerForPlayer">SetPlayerMarkerForPlayer</a> for any other player. </remarks>
+/// <remarks>If used under <a href="#OnPlayerConnect">OnPlayerConnect</a>, the affecting player will not see the color in the TAB menu. </remarks>
 native SetPlayerColor(playerid,color);
+
+/// <summary>Gets the color of the player's name and radar marker. Only works after <a href="#SetPlayerColor">SetPlayerColor</a>.</summary>
+/// <param name="playerid">The ID of the player to get the color of</param>
+/// <seealso name="SetPlayerColor"/>
+/// <seealso name="ChangeVehicleColor"/>
+/// <remarks>GetPlayerColor will return <b><c>0</c></b> unless <a href="#SetPlayerColor">SetPlayerColor</a> has been used first.</remarks>
+/// <returns>The player's color. <b><c>0</c></b> if no color set or player not connected.</returns>
 native GetPlayerColor(playerid);
+
+/// <summary>Set the skin of a player. A player's skin is their character model.</summary>
+/// <param name="playerid">The ID of the player to set the skin of</param>
+/// <param name="skinid">The <a href="http://wiki.sa-mp.com/wiki/Skins">skin</a> the player should use</param>
+/// <seealso name="GetPlayerSkin"/>
+/// <seealso name="SetSpawnInfo"/>
+/// <remarks>If a player's skin is set when they are crouching, in a vehicle, or performing certain animations, they will become frozen or otherwise glitched. This can be fixed by using <a href="#TogglePlayerControllable">TogglePlayerControllable</a>. Players can be detected as being crouched through <a href="#GetPlayerSpecialAction">GetPlayerSpecialAction</a> (<b><c>SPECIAL_ACTION_DUCK</c></b>).</remarks>
+/// <remarks>Setting a player's skin when he is dead may crash players around him.</remarks>
+/// <remarks>Note that 'success' is reported even when skin ID is invalid (not <b><c>0</c></b>-<b><c>311</c></b>, or <b><c>74</c></b>), but the skin will be set to ID <b><c>0</c></b> (CJ).</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.<p/>
+/// </returns>
 native SetPlayerSkin(playerid, skinid);
+
+/// <summary>Returns the class of the players skin.</summary>
+/// <param name="playerid">The player you want to get the skin from</param>
+/// <seealso name="SetPlayerSkin"/>
+/// <remarks>Returns the new skin after <a href="#SetSpawnInfo">SetSpawnInfo</a> is called but before the player actually respawns to get the new skin. </remarks>
+/// <remarks>Returns the old skin if the player was spawned through <a href="#SpawnPlayer">SpawnPlayer</a> function. </remarks>
+/// <returns>The skin id (<b><c>0</c></b> if invalid).</returns>
 native GetPlayerSkin(playerid);
+
 native GetPlayerCustomSkin(playerid);
+
+/// <summary>Give a player a weapon with a specified amount of ammo.</summary>
+/// <param name="playerid">The ID of the player to give a weapon to</param>
+/// <param name="weaponid">The ID of the weapon to give to the player</param>
+/// <param name="ammo">The amount of ammo to give to the player</param>
+/// <seealso name="SetPlayerArmedWeapon"/>
+/// <seealso name="GetPlayerWeapon"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.<p/>
+/// </returns>
 native GivePlayerWeapon(playerid, weaponid, ammo);
+
+/// <summary>Removes all weapons from a player.</summary>
+/// <param name="playerid">The ID of the player whose weapons to remove</param>
+/// <seealso name="GivePlayerWeapon"/>
+/// <seealso name="GetPlayerWeapon"/>
+/// <remarks>To remove individual weapons from a player, set their ammo to <b><c>0</c></b> using <a href="#SetPlayerAmmo">SetPlayerAmmo</a>.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.
+/// </returns>
 native ResetPlayerWeapons(playerid);
+
+/// <summary>Sets which weapon (that a player already has) the player is holding.</summary>
+/// <param name="playerid">The ID of the player to arm with a weapon</param>
+/// <param name="weaponid">The ID of the weapon that the player should be armed with</param>
+/// <seealso name="GivePlayerWeapon"/>
+/// <seealso name="GetPlayerWeapon"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function arms a player with a weapon they <b>already have</b>; it does not give them a new weapon. See <a href="#GivePlayerWeapon">GivePlayerWeapon</a>.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. Success is returned even when the function fails to execute (the player doesn't have the weapon specified, or it is an invalid weapon).<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player is not connected.
+/// </returns>
 native SetPlayerArmedWeapon(playerid, weaponid);
+
+/// <summary>Get the weapon and ammo in a specific player's weapon slot (e.g. the weapon in the 'SMG' slot).</summary>
+/// <param name="playerid">The ID of the player whose weapon data to retrieve</param>
+/// <param name="slot">The weapon slot to get data for (<b><c>0-12</c></b>)</param>
+/// <param name="weapons">A variable in which to store the weapon ID, passed by reference</param>
+/// <param name="ammo">A variable in which to store the ammo, passed by reference</param>
+/// <seealso name="GetPlayerWeapon"/>
+/// <seealso name="GivePlayerWeapon"/>
+/// <remarks>Old weapons with no ammo left are still returned.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player isn't connected and/or the weapon slot specified is invalid (valid is <b><c>0-12</c></b>).
+/// </returns>
 native GetPlayerWeaponData(playerid, slot, &weapons, &ammo);
+
+/// <summary>Give money to or take money from a player.</summary>
+/// <param name="playerid">The ID of the player to give money to or take money from</param>
+/// <param name="money">The amount of money to give the player. Use a minus value to take money</param>
+/// <seealso name="ResetPlayerMoney"/>
+/// <seealso name="GetPlayerMoney"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native GivePlayerMoney(playerid,money);
+
+/// <summary>Reset a player's money to $0.</summary>
+/// <param name="playerid">The ID of the player to reset the money of</param>
+/// <seealso name="GetPlayerMoney"/>
+/// <seealso name="GivePlayerMoney"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native ResetPlayerMoney(playerid);
+
+/// <summary>Sets the name of a player.</summary>
+/// <param name="playerid">The ID of the player to set the name of</param>
+/// <param name="name">The name to set. Must be 1-24 characters long and only contain valid characters (<b>0-9</b>, <b>a-z</b>, <b>A-Z</b>, <b>[]</b>, <b>()</b>, <b>$</b>, <b>@</b>, <b>.</b>, <b>_</b>, <b>=</b>)</param>
+/// <seealso name="GetPlayerName"/>
+/// <remarks>Changing the players' name to the same name but with different character cases (e.g. "John" to "JOHN") will not work. </remarks>
+/// <remarks>If used in <a href="#OnPlayerConnect">OnPlayerConnect</a>, the new name will <b>not</b> be shown for the connecting player. </remarks>
+/// <remarks>Passing a null string as the new name will crash the server. </remarks>
+/// <remarks>Player names can be up to 24 characters when using this function, but when joining the server from the SA-MP server browser, players' names must be no more than 20 and less than 3 characters (the server will deny entry). This allows for 4 characters extra when using <a href="#SetPlayerName">SetPlayerName</a>. </remarks>
+/// <returns>
+///   <b><c>1</c></b> The name was changed successfully.<p/>
+///   <b><c>0</c></b> The player already has that name.<p/>
+///   <b><c>-1</c></b> The name can not be changed (it's already in use, too long or has invalid characters).
+/// </returns>
 native SetPlayerName(playerid, const name[]);
+
+/// <summary>Retrieves the amount of money a player has.</summary>
+/// <param name="playerid">The ID of the player to get the money of</param>
+/// <seealso name="GivePlayerMoney"/>
+/// <seealso name="ResetPlayerMoney"/>
+/// <returns>The amount of money the player has.</returns>
 native GetPlayerMoney(playerid);
+
+/// <summary>Get a player's current state.</summary>
+/// <param name="playerid">The ID of the player to get the current state of</param>
+/// <seealso name="GetPlayerSpecialAction"/>
+/// <seealso name="SetPlayerSpecialAction"/>
+/// <seealso name="OnPlayerStateChange"/>
+/// <remarks>
+///   <b>States:</b><p/>
+///   <ul>
+///     <li><b><c>PLAYER_STATE_NONE</c></b> - empty (while initializing)</li>
+///     <li><b><c>PLAYER_STATE_ONFOOT</c></b> - player is on foot</li>
+///     <li><b><c>PLAYER_STATE_DRIVER</c></b> - player is the driver of a vehicle</li>
+///     <li><b><c>PLAYER_STATE_PASSENGER</c></b> - player is passenger of a vehicle</li>
+///     <li><b><c>PLAYER_STATE_WASTED</c></b> - player is dead or on class selection</li>
+///     <li><b><c>PLAYER_STATE_SPAWNED</c></b> - player is spawned</li>
+///     <li><b><c>PLAYER_STATE_SPECTATING</c></b> - player is spectating</li>
+///     <li><b><c>PLAYER_STATE_EXIT_VEHICLE</c></b> - player exits a vehicle</li>
+///     <li><b><c>PLAYER_STATE_ENTER_VEHICLE_DRIVER</c></b> - player enters a vehicle as driver</li>
+///     <li><b><c>PLAYER_STATE_ENTER_VEHICLE_PASSENGER</c></b> - player enters a vehicle as passenger </li>
+///   </ul>
+/// </remarks>
+/// <returns>The player's current state as an integer.</returns>
 native GetPlayerState(playerid);
-native GetPlayerIp(playerid, name[], len);
+
+/// <summary>Get the specified player's IP address and store it in a string.</summary>
+/// <param name="playerid">The ID of the player to get the IP address of</param>
+/// <param name="ip">The string to store the player's IP address in, passed by reference</param>
+/// <param name="len">The maximum length of the IP address (recommended 16)</param>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <seealso name="GetPlayerName"/>
+/// <seealso name="GetPlayerPing"/>
+/// <seealso name="GetPlayerVersion"/>
+/// <seealso name="OnIncomingConnection"/>
+/// <seealso name="OnPlayerConnect"/>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <remarks>This function does not work when used in <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a> because the player is already disconnected. It will return an invalid IP (<b><c>255.255.255.255</c></b>). Save players' IPs under <a href="#OnPlayerConnect">OnPlayerConnect</a> if they need to be used under <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a>. </remarks>
+/// <returns><b><c>1</c></b> on success and <b><c>0</c></b> on failure.</returns>
+native GetPlayerIp(playerid, ip[], len);
+
+/// <summary>Get the ping of a player. The ping measures the amount of time it takes for the server to 'ping' the client and for the client to send the message back.</summary>
+/// <param name="playerid">The ID of the player to get the ping of</param>
+/// <seealso name="GetPlayerIp"/>
+/// <seealso name="GetPlayerName"/>
+/// <seealso name="GetPlayerVersion"/>
+/// <remarks>Player's ping may be <b><c>65535</c></b> for a while after a player connects</remarks>
+/// <returns>The current ping of the player (expressed in milliseconds).</returns>
 native GetPlayerPing(playerid);
+
+/// <summary>Returns the ID of the weapon a player is currently holding.</summary>
+/// <param name="playerid">The ID of the player to get the currently held weapon of</param>
+/// <seealso name="GetPlayerWeaponData"/>
+/// <seealso name="GivePlayerWeapon"/>
+/// <seealso name="ResetPlayerWeapons"/>
+/// <remarks>Prior to version <b>0.3z R1-2</b>, when the player state is <b>PLAYER_STATE_PASSENGER</b> this function returns the weapon held by the player before they entered the vehicle. If a cheat is used to spawn a weapon inside a vehicle, this function will not report it.</remarks>
+/// <returns>The ID of the player's current weapon. Returns <b><c>-1</c></b> if the player specified does not exist.</returns>
 native GetPlayerWeapon(playerid);
+
+/// <summary>Check which keys a player is pressing.</summary>
+/// <param name="playerid">The ID of the player to get the keys of</param>
+/// <param name="keys">Bitmask containing the player's key states. <a href="http://wiki.sa-mp.com/wiki/Keys">List of keys</a></param>
+/// <param name="updown">Up/down state</param>
+/// <param name="leftright">Left/right state</param>
+/// <seealso name="OnPlayerKeyStateChange"/>
+/// <remarks>Only the FUNCTION of keys can be detected; not actual keys. For example, it is not possible to detect if a player presses <b>SPACE</b>, but you can detect if they press <b>SPRINT</b> (which can be mapped (assigned/binded) to ANY key (but is space by default)). </remarks>
+/// <remarks>As of update <b>0.3.7</b>, the keys "A" and "D" are not recognized when in a vehicle. However, keys "W" and "S" can be detected with the "keys" parameter. </remarks>
+/// <returns>The keys are stored in the specified variables.</returns>
 native GetPlayerKeys(playerid, &keys, &updown, &leftright);
+
+/// <summary>Get a player's name.</summary>
+/// <param name="playerid">The ID of the player to get the name of</param>
+/// <param name="name">An array into which to store the name, passed by reference</param>
+/// <param name="len">The length of the string that should be stored. Recommended to be <b><c>MAX_PLAYER_NAME</c></b></param>
+/// <seealso name="SetPlayerName"/>
+/// <seealso name="GetPlayerIp"/>
+/// <seealso name="GetPlayerPing"/>
+/// <seealso name="GetPlayerScore"/>
+/// <seealso name="GetPlayerVersion"/>
+/// <remarks>A player's name can be up to 24 characters long (as of <b>0.3d R2</b>) by using <a href="#SetPlayerName">SetPlayerName</a>. This is defined in <c>a_samp.inc</c> as <b><c>MAX_PLAYER_NAME</c></b>. However, the client can only join with a nickname between 3 and 20 characters, otherwise the connection will be rejected and the player has to quit to choose a valid name.</remarks>
+/// <returns>The length of the player's name. <b><c>0</c></b> if player specified doesn't exist.</returns>
 native GetPlayerName(playerid, const name[], len);
+
+/// <summary>Sets the game time for a player. If a player's clock is enabled (<a href="#TogglePlayerClock">TogglePlayerClock</a>) the time displayed by it will update automatically.</summary>
+/// <param name="playerid">The ID of the player to set the game time of</param>
+/// <param name="hour">Hour to set (0-23)</param>
+/// <param name="minute">Minutes to set (0-59)</param>
+/// <seealso name="SetWorldTime"/>
+/// <seealso name="GetPlayerTime"/>
+/// <seealso name="TogglePlayerClock"/>
+/// <remarks>Using this function under <a href="#OnPlayerConnect">OnPlayerConnect</a> doesn't work.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.
+/// </returns>
 native SetPlayerTime(playerid, hour, minute);
+
+/// <summary>Get the player's current game time. Set by <a href="#SetWorldTime">SetWorldTime</a> or <a href="#SetPlayerTime">SetPlayerTime</a>, or by the game automatically if <a href="#TogglePlayerClock">TogglePlayerClock</a> is used.</summary>
+/// <param name="playerid">The ID of the player to get the game time of</param>
+/// <param name="hour">A variable in which to store the hour, passed by reference</param>
+/// <param name="minute">A variable in which to store the minutes, passed by reference</param>
+/// <seealso name="SetPlayerTime"/>
+/// <seealso name="SetWorldTime"/>
+/// <seealso name="TogglePlayerClock"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.<p/>
+/// </returns>
 native GetPlayerTime(playerid, &hour, &minute);
+
+/// <summary>Toggle the in-game clock (top-right corner) for a specific player. When this is enabled, time will progress at 1 minute per second. Weather will also interpolate (slowly change over time) when set using <a href="#SetWeather">SetWeather</a>/<a href="#SetPlayerWeather">SetPlayerWeather</a>.</summary>
+/// <param name="playerid">The player whose clock you want to enable/disable</param>
+/// <param name="toggle"><b><c>1</c></b> to show and <b><c>0</c></b> to hide. Hidden by default</param>
+/// <remarks>Time is not synced with other players! Time can be synced using <a href="#SetPlayerTime">SetPlayerTime</a>.</remarks>
+/// <remarks>Time will automatically advance 6 hours when the player dies.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The specified player does not exist.
+/// </returns>
 native TogglePlayerClock(playerid, toggle);
+
+/// <summary>Set a player's weather.</summary>
+/// <param name="playerid">The ID of the player whose weather to set</param>
+/// <param name="weather">The <a href="http://wiki.sa-mp.com/wiki/WeatherID">weather</a> to set</param>
+/// <seealso name="SetWeather"/>
+/// <seealso name="SetGravity"/>
+/// <remarks>If <a href="#TogglePlayerClock">TogglePlayerClock</a> is enabled, weather will slowly change over time, instead of changing instantly.</remarks>
 native SetPlayerWeather(playerid, weather);
+
+/// <summary>Forces a player to go back to class selection.</summary>
+/// <param name="playerid">The player to send back to class selection</param>
+/// <seealso name="AddPlayerClass"/>
+/// <seealso name="SetPlayerSkin"/>
+/// <seealso name="GetPlayerSkin"/>
+/// <seealso name="OnPlayerRequestClass"/>
+/// <remarks>The player will not return to class selection until they re-spawn. This can be achieved with <a href="#TogglePlayerSpectating">TogglePlayerSpectating</a>, as seen in the below example.</remarks>
 native ForceClassSelection(playerid);
+
+/// <summary>Set a player's wanted level (6 brown stars under HUD).</summary>
+/// <param name="playerid">The ID of the player to set the wanted level of</param>
+/// <param name="level">The wanted level to set for the player (0-6)</param>
+/// <seealso name="GetPlayerWantedLevel"/>
+/// <seealso name="PlayCrimeReportForPlayer"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.
+/// </returns>
 native SetPlayerWantedLevel(playerid, level);
+
+/// <summary>Gets the wanted level of a player.</summary>
+/// <param name="playerid">The ID of the player that you want to get the wanted level of</param>
+/// <seealso name="SetPlayerWantedLevel"/>
+/// <seealso name="PlayCrimeReportForPlayer"/>
+/// <returns>The player's wanted level.</returns>
 native GetPlayerWantedLevel(playerid);
+
+/// <summary>Set a player's special fighting style. To use in-game, aim and press the 'secondary attack' key (<b>ENTER</b> by default).</summary>
+/// <param name="playerid">The ID of player to set the fighting style of</param>
+/// <param name="style">The fighting style that should be set</param>
+/// <seealso name="GetPlayerFightingStyle"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This does not affect normal fist attacks - only special/secondary attacks (aim + press 'secondary attack' key).</remarks>
+/// <remarks>
+///   <b>Fighting styles:</b><p/>
+///   <ul>
+///     <li><b><c>FIGHT_STYLE_NORMAL</c></b></li>
+///     <li><b><c>FIGHT_STYLE_BOXING</c></b></li>
+///     <li><b><c>FIGHT_STYLE_KUNGFU</c></b></li>
+///     <li><b><c>FIGHT_STYLE_KNEEHEAD</c></b></li>
+///     <li><b><c>FIGHT_STYLE_GRABKICK</c></b></li>
+///     <li><b><c>FIGHT_STYLE_ELBOW</c></b></li>
+///   </ul>
+/// </remarks>
 native SetPlayerFightingStyle(playerid, style);
+
+/// <summary>Get the fighting style the player currently using.</summary>
+/// <param name="playerid">The ID of the player to get the fighting style of</param>
+/// <seealso name="SetPlayerFightingStyle"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Fighting styles:</b><p/>
+///   <ul>
+///     <li><b><c>FIGHT_STYLE_NORMAL</c></b></li>
+///     <li><b><c>FIGHT_STYLE_BOXING</c></b></li>
+///     <li><b><c>FIGHT_STYLE_KUNGFU</c></b></li>
+///     <li><b><c>FIGHT_STYLE_KNEEHEAD</c></b></li>
+///     <li><b><c>FIGHT_STYLE_GRABKICK</c></b></li>
+///     <li><b><c>FIGHT_STYLE_ELBOW</c></b></li>
+///   </ul>
+/// </remarks>
+/// <returns>The ID of the fighting style of the player.</returns>
 native GetPlayerFightingStyle(playerid);
+
+/// <summary>Set a player's velocity on the X, Y and Z axes.</summary>
+/// <param name="playerid">The player to apply the speed to</param>
+/// <param name="X">The velocity (speed) on the X axis</param>
+/// <param name="Y">The velocity (speed) on the Y axis</param>
+/// <param name="Z">The velocity (speed) on the Z axis</param>
+/// <seealso name="GetPlayerVelocity"/>
+/// <seealso name="SetVehicleVelocity"/>
+/// <seealso name="GetVehicleVelocity"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native SetPlayerVelocity(playerid, Float:X, Float:Y, Float:Z);
+
+/// <summary>Get the velocity (speed) of a player on the X, Y and Z axes.</summary>
+/// <param name="playerid">The player to get the speed from</param>
+/// <param name="X">A float variable in which to store the velocity on the X axis, passed by reference</param>
+/// <param name="Y">A float variable in which to store the velocity on the Y axis, passed by reference</param>
+/// <param name="Z">A float variable in which to store the velocity on the Z axis, passed by reference</param>
+/// <seealso name="SetPlayerVelocity"/>
+/// <seealso name="SetVehicleVelocity"/>
+/// <seealso name="GetVehicleVelocity"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native GetPlayerVelocity( playerid, &Float:X, &Float:Y, &Float:Z );
+
+/// <summary>This function plays a crime report for a player - just like in single-player when CJ commits a crime.</summary>
+/// <param name="playerid">The ID of the player that will hear the crime report</param>
+/// <param name="suspectid">The ID of the suspect player whom will be described in the crime report</param>
+/// <param name="crime">The crime ID, which will be reported as a 10-code (i.e. 10-16 if 16 was passed as the crime)</param>
+/// <seealso name="PlayerPlaySound"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Crime list:</b><p/>
+///   <ul>
+///     <li><b><c>3</c></b> 10-71 Advise nature of fire (size, type, contents of building)</li>
+///     <li><b><c>4</c></b> 10-47 Emergency road repairs needed</li>
+///     <li><b><c>5</c></b> 10-81 Breatherlizer Report</li>
+///     <li><b><c>6</c></b> 10-24 Assignment Completed</li>
+///     <li><b><c>7</c></b> 10-21 Call () by phone</li>
+///     <li><b><c>8</c></b> 10-21 Call () by phone</li>
+///     <li><b><c>9</c></b> 10-21 Call () by phone</li>
+///     <li><b><c>10</c></b> 10-17 Meet Complainant</li>
+///     <li><b><c>11</c></b> 10-81 Breatherlizer Report</li>
+///     <li><b><c>12</c></b> 10-91 Pick up prisoner/subject</li>
+///     <li><b><c>13</c></b> 10-28 Vehicle registration information</li>
+///     <li><b><c>14</c></b> 10-81 Breathalyzer</li>
+///     <li><b><c>15</c></b> 10-28 Vehicle registration information</li>
+///     <li><b><c>16</c></b> 10-91 Pick up prisoner/subject</li>
+///     <li><b><c>17</c></b> 10-34 Riot</li>
+///     <li><b><c>18</c></b> 10-37 (Investigate) suspicious vehicle</li>
+///     <li><b><c>19</c></b> 10-81 Breathalyzer</li>
+///     <li><b><c>21</c></b> 10-7 Out of service</li>
+///     <li><b><c>22</c></b> 10-7 Out of service </li>
+///   </ul>
+/// </remarks>
 native PlayCrimeReportForPlayer(playerid, suspectid, crime);
+
+/// <summary>Play an 'audio stream' for a player. Normal audio files also work (e.g. MP3).</summary>
+/// <param name="playerid">The ID of the player to play the audio for</param>
+/// <param name="url">The url to play. Valid formats are mp3 and ogg/vorbis. A link to a .pls (playlist) file will play that playlist</param>
+/// <param name="posX">The X position at which to play the audio. Has no effect unless usepos is set to 1 (optional=<b><c>0.0</c></b>)</param>
+/// <param name="posY">The Y position at which to play the audio. Has no effect unless usepos is set to 1 (optional=<b><c>0.0</c></b>)</param>
+/// <param name="posZ">The Z position at which to play the audio. Has no effect unless usepos is set to 1 (optional=<b><c>0.0</c></b>)</param>
+/// <param name="distance">The distance over which the audio will be heard. Has no effect unless usepos is set to 1 (optional=<b><c>50.0</c></b>)</param>
+/// <param name="usepos">Use the positions and distance specified. (optional=<b><c>0</c></b>)</param>
+/// <seealso name="StopAudioStreamForPlayer"/>
+/// <seealso name="PlayerPlaySound"/>
+/// <remarks>This function was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.
+/// </returns>
 native PlayAudioStreamForPlayer(playerid, url[], Float:posX = 0.0, Float:posY = 0.0, Float:posZ = 0.0, Float:distance = 50.0, usepos = 0);
+
+/// <summary>Stops the current audio stream for a player.</summary>
+/// <param name="playerid">The player you want to stop the audio stream for</param>
+/// <seealso name="PlayAudioStreamForPlayer"/>
+/// <seealso name="PlayerPlaySound"/>
+/// <remarks>This function was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
 native StopAudioStreamForPlayer(playerid);
+
+/// <summary>Loads or unloads an interior script for a player (for example the ammunation menu).</summary>
+/// <param name="playerid">The ID of the player to load the interior script for</param>
+/// <param name="shopname">The shop script to load. Leave blank ("") to unload scripts</param>
+/// <seealso name="DisableInteriorEnterExits"/>
+/// <seealso name="SetPlayerInterior"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function does not support casino scripts.</remarks>
+/// <remarks>
+///   <b>Shop names:</b><p/>
+///   <ul>
+///     <li><b><c>"FDPIZA"</c></b> Pizza Stack</li>
+///     <li><b><c>"FDBURG"</c></b> Burger Shot</li>
+///     <li><b><c>"FDCHICK"</c></b>Cluckin' Bell</li>
+///     <li><b><c>"AMMUN1"</c></b> Ammunation 1</li>
+///     <li><b><c>"AMMUN2"</c></b> Ammunation 2</li>
+///     <li><b><c>"AMMUN3"</c></b> Ammunation 3</li>
+///     <li><b><c>"AMMUN4"</c></b> Ammunation 4</li>
+///     <li><b><c>"AMMUN5"</c></b> Ammunation 5</li>
+///   </ul>
+/// </remarks>
 native SetPlayerShopName(playerid, shopname[]);
+
+/// <summary>Set the skill level of a certain weapon type for a player.</summary>
+/// <param name="playerid">The ID of the player to set the weapon skill of</param>
+/// <param name="skill">The weapon to set the skill of</param>
+/// <param name="level">The skill level to set for that weapon, ranging from <b><c>0</c></b> to <b><c>999</c></b>. A level out of range will max it out</param>
+/// <seealso name="SetPlayerArmedWeapon"/>
+/// <seealso name="GivePlayerWeapon"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Weapon skills:</b><p/>
+///   <ul>
+///     <li><b><c>WEAPONSKILL_PISTOL(0)</c></b></li>
+///     <li><b><c>WEAPONSKILL_PISTOL_SILENCED(1)</c></b></li>
+///     <li><b><c>WEAPONSKILL_DESERT_EAGLE(2)</c></b></li>
+///     <li><b><c>WEAPONSKILL_SHOTGUN(3)</c></b></li>
+///     <li><b><c>WEAPONSKILL_SAWNOFF_SHOTGUN(4)</c></b></li>
+///     <li><b><c>WEAPONSKILL_SPAS12_SHOTGUN(5)</c></b></li>
+///     <li><b><c>WEAPONSKILL_MICRO_UZI(6)</c></b></li>
+///     <li><b><c>WEAPONSKILL_MP5(7)</c></b></li>
+///     <li><b><c>WEAPONSKILL_AK47(8)</c></b></li>
+///     <li><b><c>WEAPONSKILL_M4(9)</c></b></li>
+///     <li><b><c>WEAPONSKILL_SNIPERRIFLE(10)</c></b></li>
+///   </ul>
+/// </remarks>
 native SetPlayerSkillLevel(playerid, skill, level);
+
+/// <summary>Get the ID of the vehicle that the player is surfing (stuck to the roof of).</summary>
+/// <param name="playerid">The ID of the player you want to know the surfing vehicle ID of</param>
+/// <seealso name="GetPlayerVehicleID"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>The ID of the vehicle that the player is surfing. If they are not surfing a vehicle or the vehicle they are surfing has no driver, <b><c>INVALID_VEHICLE_ID</c></b>. If the player specified is not connected, <b><c>INVALID_VEHICLE_ID</c></b> also.</returns>
 native GetPlayerSurfingVehicleID(playerid);
+
+/// <summary>Returns the ID of the object the player is surfing on.</summary>
+/// <param name="playerid">The ID of the player surfing the object</param>
+/// <remarks>This function was added in <b>SA-MP 0.3c R3</b> and will not work in earlier versions!</remarks>
+/// <returns>The ID of the <b>moving</b> object the player is surfing. If the player isn't surfing a <b>moving</b> object, it will return <b><c>INVALID_OBJECT_ID</c></b>.</returns>
 native GetPlayerSurfingObjectID(playerid);
+
+/// <summary>Removes a standard San Andreas model for a single player within a specified range.</summary>
+/// <param name="playerid">The ID of the player to remove the objects for</param>
+/// <param name="modelid">The model to remove</param>
+/// <param name="fX">The X coordinate around which the objects will be removed</param>
+/// <param name="fY">The Y coordinate around which the objects will be removed</param>
+/// <param name="fZ">The Z coordinate around which the objects will be removed</param>
+/// <param name="fRadius">The radius around the specified point to remove objects with the specified model</param>
+/// <seealso name="DestroyObject"/>
+/// <seealso name="DestroyPlayerObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
+/// <remarks>There appears to be a limit of around <b><c>1000</c></b> lines/objects. There is no workaround. </remarks>
+/// <remarks>When removing the same object for a player, they will crash. Commonly, players crash when reconnecting to the server because the server removes buildings on <a href="#OnPlayerConnect">OnPlayerConnect</a>. </remarks>
+/// <remarks>In <b>SA-MP 0.3.7</b> you can use <b><c>-1</c></b> for the modelid to remove all objects within the specified radius.</remarks>
 native RemoveBuildingForPlayer(playerid, modelid, Float:fX, Float:fY, Float:fZ, Float:fRadius);
+
+/// <summary>Retrieves the start and end (hit) position of the last bullet a player fired.</summary>
+/// <param name="playerid">The ID of the player to get the last bullet shot information of</param>
+/// <param name="fOriginX">A float variable in which to save the X coordinate of where the bullet originated from</param>
+/// <param name="fOriginY">A float variable in which to save the Y coordinate of where the bullet originated from</param>
+/// <param name="fOriginZ">A float variable in which to save the Z coordinate of where the bullet originated from</param>
+/// <param name="fHitPosX">A float variable in which to save the X coordinate of where the bullet hit</param>
+/// <param name="fHitPosY">A float variable in which to save the Y coordinate of where the bullet hit</param>
+/// <param name="fHitPosZ">A float variable in which to save the Z coordinate of where the bullet hit</param>
+/// <seealso name="GetPlayerWeaponData"/>
+/// <seealso name="GetPlayerWeapon"/>
+/// <seealso name="VectorSize"/>
+/// <seealso name="OnPlayerWeaponShot"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function will only work when <a href="http://wiki.sa-mp.com/wiki/Lag_Compensation">lag compensation</a> is <b>enabled</b>. </remarks>
+/// <remarks>If the player hit nothing, the hit positions will be <b><c>0</c></b>. This means you can't currently calculate how far a bullet travels through open air. </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.<p/>
+/// </returns>
 native GetPlayerLastShotVectors(playerid, &Float:fOriginX, &Float:fOriginY, &Float:fOriginZ, &Float:fHitPosX, &Float:fHitPosY, &Float:fHitPosZ);
 
 // Attached to bone objects
 
 #define MAX_PLAYER_ATTACHED_OBJECTS 10 // This is the number of attached indexes available ie 10 = 0-9
 
+
+/// <summary>Attach an object to a specific bone on a player.</summary>
+/// <param name="playerid">The ID of the player to attach the object to</param>
+/// <param name="index">The index (slot) to assign the object to (0-9 since 0.3d, 0-4 in previous versions)</param>
+/// <param name="modelid">The <a href="http://wiki.sa-mp.com/wiki/Objects">model</a> to attach</param>
+/// <param name="bone">The bone to attach the object to</param>
+/// <param name="fOffsetX">X axis offset for the object position (optional=<b><c>0.0</c></b>)</param>
+/// <param name="fOffsetY">Y axis offset for the object position (optional=<b><c>0.0</c></b>)</param>
+/// <param name="fOffsetZ">Z axis offset for the object position (optional=<b><c>0.0</c></b>)</param>
+/// <param name="fRotX">X axis rotation of the object (optional=<b><c>0.0</c></b>)</param>
+/// <param name="fRotY">Y axis rotation of the object (optional=<b><c>0.0</c></b>)</param>
+/// <param name="fRotZ">Z axis rotation of the object (optional=<b><c>0.0</c></b>)</param>
+/// <param name="fScaleX">X axis scale of the object (optional=<b><c>1.0</c></b>)</param>
+/// <param name="fScaleY">Y axis scale of the object (optional=<b><c>1.0</c></b>)</param>
+/// <param name="fScaleZ">Z axis scale of the object (optional=<b><c>1.0</c></b>)</param>
+/// <param name="materialcolor1">The first object color to set <b>ARGB</b> (optional=<b><c>0</c></b>)</param>
+/// <param name="materialcolor2">The second object color to set <b>ARGB</b> (optional=<b><c>0</c></b>)</param>
+/// <seealso name="RemovePlayerAttachedObject"/>
+/// <seealso name="IsPlayerAttachedObjectSlotUsed"/>
+/// <seealso name="EditAttachedObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c</b> and will not work in earlier versions!</remarks>
+/// <remarks>In version <b>0.3d</b> and onwards, <b><c>10</c></b> objects can be attached to a single player (index <b><c>0</c></b>-<b><c>9</c></b>). In earlier versions, the limit is <b><c>5</c></b> (index <b><c>0</c></b>-<b><c>4</c></b>).</remarks>
+/// <remarks>This function is separate from the <a href="#CreateObject">CreateObject</a> / <a href="#CreatePlayerObject">CreatePlayerObject</a> pools.</remarks>
+/// <remarks>
+///   <b>Bone IDs:</b><p/>
+///   <ul>
+///     <li><b><c>1</c></b> - spine</li>
+///     <li><b><c>2</c></b> - head</li>
+///     <li><b><c>3</c></b> - left upper arm</li>
+///     <li><b><c>4</c></b> - right upper arm</li>
+///     <li><b><c>5</c></b> - left hand</li>
+///     <li><b><c>6</c></b> - right hand</li>
+///     <li><b><c>7</c></b> - left thigh</li>
+///     <li><b><c>8</c></b> - right thigh</li>
+///     <li><b><c>9</c></b> - left foot</li>
+///     <li><b><c>10</c></b> - right foot</li>
+///     <li><b><c>11</c></b> - right calf</li>
+///     <li><b><c>12</c></b> - left calf</li>
+///     <li><b><c>13</c></b> - left forearm</li>
+///     <li><b><c>14</c></b> - right forearm</li>
+///     <li><b><c>15</c></b> - left clavicle (shoulder)</li>
+///     <li><b><c>16</c></b> - right clavicle (shoulder)</li>
+///     <li><b><c>17</c></b> - neck</li>
+///     <li><b><c>18</c></b> - jaw </li>
+///   </ul>
+/// </remarks>
+/// <returns><b><c>1</c></b> on success, <b><c>0</c></b> on failure.</returns>
 native SetPlayerAttachedObject(playerid, index, modelid, bone, Float:fOffsetX = 0.0, Float:fOffsetY = 0.0, Float:fOffsetZ = 0.0, Float:fRotX = 0.0, Float:fRotY = 0.0, Float:fRotZ = 0.0, Float:fScaleX = 1.0, Float:fScaleY = 1.0, Float:fScaleZ = 1.0, materialcolor1 = 0, materialcolor2 = 0);
+
+/// <summary>Remove an attached object from a player.</summary>
+/// <param name="playerid">The ID of the player to remove the object from</param>
+/// <param name="index">The index of the object to remove (set with <a href="#SetPlayerAttachedObject">SetPlayerAttachedObject</a>)</param>
+/// <seealso name="SetPlayerAttachedObject"/>
+/// <seealso name="IsPlayerAttachedObjectSlotUsed"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> on success, <b><c>0</c></b> on failure.</returns>
 native RemovePlayerAttachedObject(playerid, index);
+
+/// <summary>Check if a player has an object attached in the specified index (slot).</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <param name="index">The index (slot) to check</param>
+/// <seealso name="SetPlayerAttachedObject"/>
+/// <seealso name="RemovePlayerAttachedObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if used, <b><c>0</c></b> if not.</returns>
 native IsPlayerAttachedObjectSlotUsed(playerid, index);
+
+/// <summary>Enter edition mode for an attached object.</summary>
+/// <param name="playerid">The ID of the player to enter in to edition mode</param>
+/// <param name="index">The index (slot) of the attached object to edit</param>
+/// <seealso name="SetPlayerAttachedObject"/>
+/// <seealso name="RemovePlayerAttachedObject"/>
+/// <seealso name="IsPlayerAttachedObjectSlotUsed"/>
+/// <seealso name="EditObject"/>
+/// <seealso name="EditPlayerObject"/>
+/// <seealso name="SelectObject"/>
+/// <seealso name="CancelEdit"/>
+/// <seealso name="OnPlayerEditAttachedObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>You can move the camera while editing by pressing and holding the <b>spacebar</b> (or <b>W</b> in vehicle) and moving your mouse.</remarks>
+/// <remarks>
+///   There are 7 clickable buttons in edition mode.<p/>
+///   The three single icons that have X/Y/Z on them can be dragged to edit position/rotation/scale.<p/>
+///   The four buttons in a row are to select the edition mode and save edition: [Move] [Rotate] [Scale] [Save].<p/>
+///   Clicking save will call <a href="#OnPlayerEditAttachedObject">OnPlayerEditAttachedObject</a>.
+/// </remarks>
+/// <remarks>Players will be able to scale objects up to a very large or negative value size. Limits should be put in place using <a href="#OnPlayerEditAttachedObject">OnPlayerEditAttachedObject</a> to abort the edit.</remarks>
+/// <returns><b><c>1</c></b> on success and <b><c>0</c></b> on failure.</returns>
 native EditAttachedObject(playerid, index);
 
 // Per-player TextDraws
+
+/// <summary>Creates a textdraw for a single player. This can be used as a way around the <a href="#TextDrawCreate">global</a> text-draw limit.</summary>
+/// <param name="playerid">The ID of the player to create the textdraw for</param>
+/// <param name="x">X-Coordinate</param>
+/// <param name="y">Y-Coordinate</param>
+/// <param name="text">The text in the textdraw</param>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   If you choose values for y that are less than 1, the first text row will be invisible and only the shadow is visible.<p/>
+///   <paramref name="text"/> must <b>NOT</b> be empty or the server will crash! If you need a textdraw that shows nothing, use " " (a space) or _ (underscore)<p/>
+///   If the last character in the text is a space (" "), the text will all be blank.<p/>
+///   If part of the text is off-screen, the color of the text will not show, only the shadow (if enabled) will. <p/>
+/// </remarks>
+/// <remarks>
+///   This applies ONLY to sa-mp versions before <b>0.3z</b>:<p/><p/>
+///   Maximum length of textdraw is <b><c>800</c></b> characters. Longer text will crash the client in older versions.<p/>
+///   If you use color codes (such as <b><c>~R~ ~G~</c></b>) beyond 255th character the client will crash trying to display the textdraw. <p/>
+/// </remarks>
+/// <remarks>Keyboard key mapping codes (such as <b><c>~k~~VEHICLE_ENTER_EXIT~</c></b> Doesn't work beyond 255th character. </remarks>
+/// <remarks>
+///   The x,y coordinate is the top left coordinate for the text draw area based on a <b><c>640x480</c></b> "canvas" (irrespective of screen resolution). If you plan on using <a href="#PlayerTextDrawAlignment">PlayerTextDrawAlignment</a> with alignment <b><c>3</c></b> (right), the x,y coordinate is the top right coordinate for the text draw.<p/>
+///   This function merely CREATES the textdraw, you must use <a href="#PlayerTextDrawShow">PlayerTextDrawShow</a> to show it to a player.<p/>
+///   It is recommended to use WHOLE numbers instead of decimal positions when creating player textdraws to ensure resolution friendly design. <p/>
+/// </remarks>
+/// <remarks>Player-textdraws are automatically destroyed when a player disconnects.</remarks>
+/// <returns>The ID of the created textdraw.</returns>
 native PlayerText:CreatePlayerTextDraw(playerid, Float:x, Float:y, text[]);
+
+/// <summary>Destroy a player-textdraw.</summary>
+/// <param name="playerid">The ID of the player who's player-textdraw to destroy</param>
+/// <param name="text">The ID of the textdraw to destroy</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawDestroy(playerid, PlayerText:text);
+
+/// <summary>Sets the width and height of the letters in a player-textdraw.</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to set the letter size of</param>
+/// <param name="text">The ID of the player-textdraw to change the letter size of</param>
+/// <param name="x">Width of a char</param>
+/// <param name="y">Height of a char</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>When using this function purely for the benefit of affecting the textdraw box, multiply 'Y' by <b><c>0.135</c></b> to convert to <a href="#TextDrawTextSize">TextDrawTextSize</a>-like measurements</remarks>
+/// <remarks>Fonts appear to look the best with an X to Y ratio of <b><c>1</c></b> to <b><c>4</c></b> (e.g. if x is <b><c>0.5</c></b> then y should be <b><c>2</c></b>).</remarks>
 native PlayerTextDrawLetterSize(playerid, PlayerText:text, Float:x, Float:y);
+
+/// <summary>Change the size of a player-textdraw (box if <a href="#PlayerTextDrawUseBox">PlayerTextDrawUseBox</a> is enabled and/or clickable area for use with <a href="#PlayerTextDrawSetSelectable">PlayerTextDrawSetSelectable</a>).</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to set the size of</param>
+/// <param name="text">The ID of the player-textdraw to set the size of</param>
+/// <param name="x">The size on the X axis (left/right) following the same 640x480 grid as <a href="#TextDrawCreate">TextDrawCreate</a></param>
+/// <param name="y">The size on the Y axis (up/down) following the same 640x480 grid as <a href="#TextDrawCreate">TextDrawCreate</a></param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   The x and y have different meanings with different PlayerTextDrawAlignment values:<p/>
+///   <ul>
+///     <li><b><c>1</c></b> (left): they are the right-most corner of the box, absolute coordinates.</li>
+///     <li><b><c>2</c></b> (center): they need to inverted (switch the two) and the x value is the overall width of the box.</li>
+///     <li><b><c>3</c></b> (right): the x and y are the coordinates of the left-most corner of the box </li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   Using font type <b><c>4</c></b> (sprite) and <b><c>5</c></b> (model preview) converts X and Y of this function from corner coordinates to WIDTH and HEIGHT (offsets).<p/>
+///   The TextDraw box starts <b><c>10.0</c></b> units up and <b><c>5.0</c></b> to the left as the origin (<a href="#TextDrawCreate">TextDrawCreate</a> coordinate).<p/>
+///   This function defines the clickable area for use with <a href="#PlayerTextDrawSetSelectable">PlayerTextDrawSetSelectable</a>, whether a box is shown or not.
+/// </remarks>
 native PlayerTextDrawTextSize(playerid, PlayerText:text, Float:x, Float:y);
+
+/// <summary>Set the text alignment of a player-textdraw.</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to set the alignment of</param>
+/// <param name="text">The ID of the player-textdraw to set the alignment of</param>
+/// <param name="alignment"><b><c>1</c></b>-left <b><c>2</c></b>-centered <b><c>3</c></b>-right</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>For alignment <b><c>2</c></b> (center) the x and y values of TextSize need to be swapped, see notes at <a href="#PlayerTextDrawTextSize">PlayerTextDrawTextSize</a>. </remarks>
 native PlayerTextDrawAlignment(playerid, PlayerText:text, alignment);
+
+/// <summary>Sets the text color of a player-textdraw.</summary>
+/// <param name="playerid">The ID of the player who's textdraw to set the color of</param>
+/// <param name="text">The TextDraw to change</param>
+/// <param name="color">The color in hexadecimal format</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>You can also use Gametext colors in textdraws.</remarks>
+/// <remarks>The textdraw must be re-shown to the player in order to update the color.</remarks>
 native PlayerTextDrawColor(playerid, PlayerText:text, color);
+
+/// <summary>Toggle the box on a player-textdraw.</summary>
+/// <param name="playerid">The ID of the player whose textdraw to toggle the box of</param>
+/// <param name="text">The ID of the player-textdraw to toggle the box of</param>
+/// <param name="use"><b><c>1</c></b> to use a box or <b><c>0</c></b> to not use a box</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawUseBox(playerid, PlayerText:text, use);
+
+/// <summary>Sets the color of a textdraw's box (<a href="#PlayerTextDrawUseBox">PlayerTextDrawUseBox</a>).</summary>
+/// <param name="playerid">The ID of the player whose textdraw to set the box color of</param>
+/// <param name="text">The ID of the player textdraw to set the box color of</param>
+/// <param name="color">The color to set. Alpha (transparency) is supported</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawBoxColor(playerid, PlayerText:text, color);
+
+/// <summary>Show a player-textdraw to the player it was created for.</summary>
+/// <param name="playerid">The ID of the player to show the textdraw for</param>
+/// <param name="text">The ID of the textdraw to show</param>
+/// <param name="size">The size of the shadow. <b><c>0</c></b> will hide the shadow</param>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawSetShadow(playerid, PlayerText:text, size);
+
+/// <summary>Set the outline of a player-textdraw. The outline colour cannot be changed unless <a href="#PlayerTextDrawBackgroundColor">PlayerTextDrawBackgroundColor</a> is used.</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to set the outline of</param>
+/// <param name="text">The ID of the player-textdraw to set the outline of</param>
+/// <param name="size">The thickness of the outline</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawSetOutline(playerid, PlayerText:text, size);
+
+/// <summary>Adjust the background color of a player-textdraw.</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to set the background color of</param>
+/// <param name="text">The ID of the player-textdraw to set the background color of</param>
+/// <param name="color">The color that the textdraw should be set to</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>If <a href="#PlayerTextDrawSetOutline">PlayerTextDrawSetOutline</a> is used with size &gt; 0, the outline color will match the color used in <a href="#PlayerTextDrawBackgroundColor">PlayerTextDrawBackgroundColor</a>. Changing the value of color seems to alter the color used in <a href="#PlayerTextDrawColor">PlayerTextDrawColor</a></remarks>
 native PlayerTextDrawBackgroundColor(playerid, PlayerText:text, color);
+
+/// <summary>Change the font of a player-textdraw.</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to change the font of</param>
+/// <param name="text">The ID of the player-textdraw to change the font of</param>
+/// <param name="font">There are four font styles. A font value greater than <b><c>3</c></b> does not display, and anything greater than <b><c>16</c></b> crashes the client. See <a href="http://wiki.sa-mp.com/wiki/PlayerTextDrawFont">http://wiki.sa-mp.com/wiki/PlayerTextDrawFont</a></param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawFont(playerid, PlayerText:text, font);
+
+/// <summary>Appears to scale text spacing to a proportional ratio. Useful when using <a href="#PlayerTextDrawLetterSize">PlayerTextDrawLetterSize</a> to ensure the text has even character spacing.</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to set the proportionality of</param>
+/// <param name="text">The ID of the player-textdraw to set the proportionality of</param>
+/// <param name="set"><b><c>1</c></b> to enable proportionality, <b><c>0</c></b> to disable</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawSetProportional(playerid, PlayerText:text, set);
+
+/// <summary>Toggles whether a player-textdraw can be selected or not.</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to set the selectability of</param>
+/// <param name="text">The ID of the player-textdraw to set the selectability of</param>
+/// <param name="set">Set the player-textdraw selectable (<b><c>1</c></b>) or non-selectable (<b><c>0</c></b>). By default this is <b><c>0</c></b></param>
+/// <seealso name="SelectTextDraw"/>
+/// <seealso name="CancelSelectTextDraw"/>
+/// <seealso name="OnPlayerClickPlayerTextDraw"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks><a href="#PlayerTextDrawSetSelectable">PlayerTextDrawSetSelectable</a> MUST be used BEFORE the textdraw is shown to the player.</remarks>
+/// <remarks>Use <a href="#PlayerTextDrawTextSize">PlayerTextDrawTextSize</a> to define the clickable area.</remarks>
 native PlayerTextDrawSetSelectable(playerid, PlayerText:text, set);
+
+/// <summary>Show a player-textdraw to the player it was created for.</summary>
+/// <param name="playerid">The ID of the player to show the textdraw for</param>
+/// <param name="text">The ID of the textdraw to show</param>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawShow(playerid, PlayerText:text);
+
+/// <summary>Hide a player-textdraw from the player it was created for.</summary>
+/// <param name="playerid">The ID of the player to hide the textdraw for</param>
+/// <param name="text">The ID of the textdraw to hide</param>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawSetString"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
 native PlayerTextDrawHide(playerid, PlayerText:text);
+
+/// <summary>Change the text of a player-textdraw.</summary>
+/// <param name="playerid">The ID of the player who's textdraw string to set</param>
+/// <param name="text">The ID of the textdraw to change</param>
+/// <param name="string">The new string for the TextDraw</param>
+/// <seealso name="CreatePlayerTextDraw"/>
+/// <seealso name="PlayerTextDrawDestroy"/>
+/// <seealso name="PlayerTextDrawColor"/>
+/// <seealso name="PlayerTextDrawBoxColor"/>
+/// <seealso name="PlayerTextDrawBackgroundColor"/>
+/// <seealso name="PlayerTextDrawAlignment"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="PlayerTextDrawLetterSize"/>
+/// <seealso name="PlayerTextDrawTextSize"/>
+/// <seealso name="PlayerTextDrawSetOutline"/>
+/// <seealso name="PlayerTextDrawSetShadow"/>
+/// <seealso name="PlayerTextDrawSetProportional"/>
+/// <seealso name="PlayerTextDrawUseBox"/>
+/// <seealso name="PlayerTextDrawShow"/>
+/// <seealso name="PlayerTextDrawHide"/>
+/// <remarks>This feature (player-textdraws) was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>There are limits to the length of textdraw strings! See <a href="http://wiki.sa-mp.com/wiki/Limits">Limits</a> for more info.</remarks>
+/// <remarks>You don't have to show the TextDraw again in order to apply the changes.</remarks>
 native PlayerTextDrawSetString(playerid, PlayerText:text, string[]);
+
+/// <summary>Sets a player textdraw 2D preview sprite of a specified model ID.</summary>
+/// <param name="playerid">The PlayerTextDraw player ID</param>
+/// <param name="text">The textdraw id that will display the 3D preview</param>
+/// <param name="modelindex">The GTA SA or SA:MP model ID to display</param>
+/// <seealso name="PlayerTextDrawSetPreviewRot"/>
+/// <seealso name="PlayerTextDrawSetPreviewVehCol"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="OnPlayerClickPlayerTextDraw"/>
+/// <remarks>This function was added in <b>SA-MP 0.3x</b> and will not work in earlier versions!</remarks>
+/// <remarks>The textdraw MUST use the font type <b><c>TEXT_DRAW_FONT_MODEL_PREVIEW</c></b> in order for this function to have effect.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. If an invalid model is passed 'success' is reported, but the model will appear as a yellow/black question mark.<p/>
+///   <b><c>0</c></b>: The function failed to execute. Player and/or textdraw do not exist.
+/// </returns>
 native PlayerTextDrawSetPreviewModel(playerid, PlayerText:text, modelindex);
+
+/// <summary>Sets the rotation and zoom of a 3D model preview player-textdraw.</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to change</param>
+/// <param name="text">The ID of the player-textdraw to change</param>
+/// <param name="fRotX">The X rotation value</param>
+/// <param name="fRotY">The Y rotation value</param>
+/// <param name="fRotZ">The Z rotation value</param>
+/// <param name="fZoom">The zoom value, smaller values make the camera closer and larger values make the camera further away (optional=<b><c>1.0</c></b>)</param>
+/// <seealso name="TextDrawSetPreviewRot"/>
+/// <seealso name="PlayerTextDrawSetPreviewModel"/>
+/// <seealso name="PlayerTextDrawSetPreviewVehCol"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="OnPlayerClickPlayerTextDraw"/>
+/// <remarks>This function was added in <b>SA-MP 0.3x</b> and will not work in earlier versions!</remarks>
+/// <remarks>The textdraw MUST use the font type <b><c>TEXT_DRAW_FONT_MODEL_PREVIEW</c></b> and already have a model set in order for this function to have effect.</remarks>
 native PlayerTextDrawSetPreviewRot(playerid, PlayerText:text, Float:fRotX, Float:fRotY, Float:fRotZ, Float:fZoom = 1.0);
+
+/// <summary>Set the color of a vehicle in a player-textdraw model preview (if a vehicle is shown).</summary>
+/// <param name="playerid">The ID of the player whose player-textdraw to change</param>
+/// <param name="text">The ID of the player's player-textdraw to change</param>
+/// <param name="color1">The <a href="http://wiki.sa-mp.com/wiki/Vehicle_Color_IDs">color</a> to set the vehicle's primary color to</param>
+/// <param name="color2">The <a href="http://wiki.sa-mp.com/wiki/Vehicle_Color_IDs">color</a> to set the vehicle's secondary color to</param>
+/// <seealso name="PlayerTextDrawSetPreviewModel"/>
+/// <seealso name="PlayerTextDrawSetPreviewRot"/>
+/// <seealso name="PlayerTextDrawFont"/>
+/// <seealso name="OnPlayerClickPlayerTextDraw"/>
+/// <remarks>This function was added in <b>SA-MP 0.3x</b> and will not work in earlier versions!</remarks>
+/// <remarks>The textdraw MUST use the font <b><c>TEXT_DRAW_FONT_MODEL_PREVIEW</c></b> and be showing a vehicle in order for this function to have effect.</remarks>
 native PlayerTextDrawSetPreviewVehCol(playerid, PlayerText:text, color1, color2);
 
 // Per-player variable system (PVars)
+
+/// <summary>Set an integer player variable.</summary>
+/// <param name="playerid">The ID of the player whose player variable will be set</param>
+/// <param name="varname">The name of the player variable</param>
+/// <param name="int_value">The integer to be set</param>
+/// <seealso name="GetPVarInt"/>
+/// <seealso name="SetPVarString"/>
+/// <seealso name="GetPVarString"/>
+/// <seealso name="SetPVarFloat"/>
+/// <seealso name="GetPVarFloat"/>
+/// <seealso name="DeletePVar"/>
+/// <remarks>Variables aren't reset until after <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a> is called, so the values are still accessible in <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a>.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. Either the player specified is not connected, or the variable name is null or over 40 characters.
+/// </returns>
 native SetPVarInt(playerid, varname[], int_value);
+
+/// <summary>Gets an integer player variable's value.</summary>
+/// <param name="playerid">The ID of the player whose player variable to get</param>
+/// <param name="varname">The name of the player variable (case-insensitive). Assigned in SetPVarInt</param>
+/// <seealso name="SetPVarInt"/>
+/// <seealso name="SetPVarString"/>
+/// <seealso name="GetPVarString"/>
+/// <seealso name="SetPVarFloat"/>
+/// <seealso name="GetPVarFloat"/>
+/// <seealso name="DeletePVar"/>
+/// <returns>The integer value of the specified player variable. It will still return <b><c>0</c></b> if the variable is not set, or the player does not exist.</returns>
 native GetPVarInt(playerid, varname[]);
+
+/// <summary>Saves a string into a player variable.</summary>
+/// <param name="playerid">The ID of the player whose player variable will be set</param>
+/// <param name="varname">The name of the player variable</param>
+/// <param name="string_value">The string you want to save in the player variable</param>
+/// <seealso name="SetPVarInt"/>
+/// <seealso name="GetPVarInt"/>
+/// <seealso name="GetPVarString"/>
+/// <seealso name="SetPVarFloat"/>
+/// <seealso name="GetPVarFloat"/>
+/// <seealso name="DeletePVar"/>
 native SetPVarString(playerid, varname[], string_value[]);
+
+/// <summary>Gets a player variable as a string.</summary>
+/// <param name="playerid">The ID of the player whose player variable to get</param>
+/// <param name="varname">The name of the player variable, set by <a href="#SetPVarString">SetPVarString</a></param>
+/// <param name="string_return">The array in which to store the string value in, passed by reference</param>
+/// <param name="len">The maximum length of the returned string</param>
+/// <seealso name="SetPVarString"/>
+/// <seealso name="SetPVarInt"/>
+/// <seealso name="GetPVarInt"/>
+/// <seealso name="SetPVarFloat"/>
+/// <seealso name="GetPVarFloat"/>
+/// <seealso name="DeletePVar"/>
+/// <remarks>If length of string is zero (value not set), string_return text will not be updated or set to anything and will remain with old data, neccesying that you clear the variable to blank value if <a href="#GetPVarString">GetPVarString</a> returns <b><c>0</c></b> if that behavior is undesired </remarks>
+/// <returns>The length of the string.</returns>
 native GetPVarString(playerid, varname[], string_return[], len);
+
+/// <summary>Set a float player variable's value.</summary>
+/// <param name="playerid">The ID of the player whose player variable will be set</param>
+/// <param name="varname">The name of the player variable</param>
+/// <param name="float_value">The float you want to save in the player variable</param>
+/// <seealso name="SetPVarInt"/>
+/// <seealso name="GetPVarInt"/>
+/// <seealso name="SetPVarString"/>
+/// <seealso name="GetPVarString"/>
+/// <seealso name="GetPVarFloat"/>
+/// <seealso name="DeletePVar"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. Either the player specified is not connected, or the variable name is null or over 40 characters.
+/// </returns>
 native SetPVarFloat(playerid, varname[], Float:float_value);
+
+/// <summary>Gets a player variable as a float.</summary>
+/// <param name="playerid">The ID of the player whose player variable you want to get</param>
+/// <param name="varname">The name of the player variable</param>
+/// <seealso name="SetPVarInt"/>
+/// <seealso name="GetPVarInt"/>
+/// <seealso name="SetPVarString"/>
+/// <seealso name="GetPVarString"/>
+/// <seealso name="SetPVarFloat"/>
+/// <seealso name="DeletePVar"/>
+/// <returns>The float from the specified player variable.</returns>
 native Float:GetPVarFloat(playerid, varname[]);
+
+/// <summary>Deletes a previously set player variable.</summary>
+/// <param name="playerid">The ID of the player whose player variable to delete</param>
+/// <param name="varname">The name of the player variable to delete</param>
+/// <seealso name="SetPVarInt"/>
+/// <seealso name="GetPVarInt"/>
+/// <seealso name="SetPVarString"/>
+/// <seealso name="GetPVarString"/>
+/// <seealso name="SetPVarFloat"/>
+/// <seealso name="GetPVarFloat"/>
+/// <remarks>Once a variable is deleted, attempts to retrieve the value will return <b><c>0</c></b> (for integers and floats and <b><c>NULL</c></b> for strings).</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. Either the player specified isn't connected or there is no variable set with the given name.
+/// </returns>
 native DeletePVar(playerid, varname[]);
 
 // PVar enumeration
@@ -171,35 +1557,397 @@ native DeletePVar(playerid, varname[]);
 #define PLAYER_VARTYPE_STRING		2
 #define PLAYER_VARTYPE_FLOAT		3
 
+
+/// <summary>Each PVar (player-variable) has its own unique identification number for lookup, this function returns the highest ID set for a player.</summary>
+/// <param name="playerid">The ID of the player to get the upper PVar index of</param>
+/// <seealso name="GetPVarNameAtIndex"/>
+/// <seealso name="GetPVarType"/>
+/// <returns>The highest set PVar ID.</returns>
 native GetPVarsUpperIndex(playerid);
+
+/// <summary>Retrieve the name of a player's pVar via the index.</summary>
+/// <param name="playerid">The ID of the player whose player variable to get the name of</param>
+/// <param name="index">The index of the player's pVar</param>
+/// <param name="ret_varname">A string to store the pVar's name in, passed by reference</param>
+/// <param name="ret_len">The max length of the returned string, use sizeof()</param>
+/// <seealso name="GetPVarType"/>
+/// <seealso name="GetPVarInt"/>
+/// <seealso name="GetPVarFloat"/>
+/// <seealso name="GetPVarString"/>
 native GetPVarNameAtIndex(playerid, index, ret_varname[], ret_len);
+
+/// <summary>Gets the type (integer, float or string) of a player variable.</summary>
+/// <param name="playerid">The ID of the player whose player variable to get the type of</param>
+/// <param name="varname">The name of the player variable to get the type of</param>
+/// <seealso name="SetPVarInt"/>
+/// <seealso name="GetPVarInt"/>
+/// <seealso name="SetPVarString"/>
+/// <seealso name="GetPVarString"/>
+/// <seealso name="SetPVarFloat"/>
+/// <seealso name="GetPVarFloat"/>
+/// <seealso name="DeletePVar"/>
+/// <remarks>
+///   <b>Variable types:</b><p/>
+///   <ul>
+///     <li><b><c>PLAYER_VARTYPE_NONE</c></b> (pVar with name given does not exist)</li>
+///     <li><b><c>PLAYER_VARTYPE_INT</c></b></li>
+///     <li><b><c>PLAYER_VARTYPE_STRING</c></b></li>
+///     <li><b><c>PLAYER_VARTYPE_FLOAT</c></b></li>
+///   </ul>
+/// </remarks>
+/// <returns>Returns the type of the PVar. See table below.</returns>
 native GetPVarType(playerid, varname[]);
 
 #define MAX_CHATBUBBLE_LENGTH 144
+
+/// <summary>Creates a chat bubble above a player's name tag.</summary>
+/// <param name="playerid">The player which should have the chat bubble</param>
+/// <param name="text">The text to display</param>
+/// <param name="color">The text color</param>
+/// <param name="drawdistance">The distance from where players are able to see the chat bubble</param>
+/// <param name="expiretime">The time in miliseconds the bubble should be displayed for</param>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>You can't see your own chatbubbles. The same applies to attached 3D text labels.</remarks>
+/// <remarks>You can use color embedding for multiple colors in the message.</remarks>
 native SetPlayerChatBubble(playerid, text[], color, Float:drawdistance, expiretime);
 
 // Player control
+
+/// <summary>Puts a player in a vehicle.</summary>
+/// <param name="playerid">The ID of the player to put in a vehicle</param>
+/// <param name="vehicleid">The ID of the vehicle to put the player in</param>
+/// <param name="seatid">The ID of the seat to put the player in</param>
+/// <seealso name="RemovePlayerFromVehicle"/>
+/// <seealso name="GetPlayerVehicleID"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <seealso name="OnPlayerEnterVehicle"/>
+/// <remarks>If this function is used on a player that is already in a vehicle, other players will still see them in their previous vehicle. To fix this, first remove the player from the vehicle.</remarks>
+/// <remarks>If the seat is invalid or is taken, will cause a crash when they EXIT the vehicle.</remarks>
+/// <remarks>You can use <a href="#GetPlayerVehicleSeat">GetPlayerVehicleSeat</a> in a loop to check if a seat is occupied by any players.</remarks>
+/// <remarks>
+///   <b>Seats:</b><p/>
+///   <ul>
+///     <li><b><c>0</c></b> - driver.</li>
+///     <li><b><c>1</c></b> - front passenger.</li>
+///     <li><b><c>2</c></b> - back-left passenger.</li>
+///     <li><b><c>3</c></b> - back-right passenger.</li>
+///     <li><b><c>4+</c></b> - passenger seats (coach etc.).</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player or vehicle don't exist.
+/// </returns>
 native PutPlayerInVehicle(playerid, vehicleid, seatid);
+
+/// <summary>This function gets the ID of the vehicle the player is currently in. Note: <b>NOT</b> the model id of the vehicle. See <a href="#GetVehicleModel">GetVehicleModel</a> for that.</summary>
+/// <param name="playerid">The ID of the player in the vehicle that you want to get the ID of</param>
+/// <seealso name="IsPlayerInVehicle"/>
+/// <seealso name="IsPlayerInAnyVehicle"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <seealso name="GetVehicleModel"/>
+/// <returns>ID of the vehicle or <b><c>0</c></b> if not in a vehicle.</returns>
 native GetPlayerVehicleID(playerid);
+
+/// <summary>Find out which seat a player is in.</summary>
+/// <param name="playerid">The ID of the player you want to get the seat of</param>
+/// <seealso name="GetPlayerVehicleID"/>
+/// <seealso name="PutPlayerInVehicle"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>Sometimes the result can be <b><c>128</c></b> which is an invalid seat ID. Circumstances of this are not yet known, but it is best to discard information when returned seat number is <b><c>128</c></b>.</remarks>
+/// <returns>The ID of the seat the player is in. <b><c>-1</c></b> is not in vehicle, <b><c>0</c></b> is the driver, <b><c>1</c></b> is the front passenger, and <b><c>2</c></b> &amp; <b><c>3</c></b> are the rear passengers.</returns>
 native GetPlayerVehicleSeat(playerid);
+
+/// <summary>Removes/ejects a player from their vehicle.</summary>
+/// <param name="playerid">The ID of the player to remove from their vehicle</param>
+/// <seealso name="PutPlayerInVehicle"/>
+/// <remarks>
+///   The exiting animation is not synced for other players.<p/>
+///   This function will not work when used in <a href="#OnPlayerEnterVehicle">OnPlayerEnterVehicle</a>, because the player isn't in the vehicle when the callback is called. Use <a href="#OnPlayerStateChange">OnPlayerStateChange</a> instead.<p/>
+///   The player isn't removed if he is in a RC Vehicle.
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native RemovePlayerFromVehicle(playerid);
+
+/// <summary>Toggles whether a player can control their character or not. The player will also be unable to move their camera.</summary>
+/// <param name="playerid">The ID of the player to toggle the controllability of</param>
+/// <param name="toggle"><b><c>0</c></b> to make them uncontrollable, <b><c>1</c></b> to make them controllable</param>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.
+/// </returns>
 native TogglePlayerControllable(playerid, toggle);
+
+/// <summary>Plays the specified sound for a player.</summary>
+/// <param name="playerid">The ID of the player for whom to play the sound</param>
+/// <param name="soundid">The sound to play</param>
+/// <param name="x">X coordinate for the sound to play at. (0 for no position)</param>
+/// <param name="y">Y coordinate for the sound to play at. (0 for no position)</param>
+/// <param name="z">Z coordinate for the sound to play at. (0 for no position)</param>
+/// <seealso name="PlayCrimeReportForPlayer"/>
+/// <seealso name="PlayAudioStreamForPlayer"/>
+/// <seealso name="StopAudioStreamForPlayer"/>
+/// <remarks>Only use the coordinates if you want the sound to be played at a certain position. Set coordinates all to 0 to just play the sound.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native PlayerPlaySound(playerid, soundid, Float:x, Float:y, Float:z);
+
+/// <summary>Apply an animation to a player.</summary>
+/// <param name="playerid">The ID of the player to apply the animation to</param>
+/// <param name="animlib">The animation library from which to apply an animation</param>
+/// <param name="animname">The name of the animation to apply, within the specified library</param>
+/// <param name="fDelta">The speed to play the animation (use 4.1)</param>
+/// <param name="loop">If set to <b><c>1</c></b>, the animation will loop. If set to <b><c>0</c></b>, the animation will play once</param>
+/// <param name="lockx">If set to <b><c>0</c></b>, the player is returned to their old X coordinate once the animation is complete (for animations that move the player such as walking). <b><c>1</c></b> will not return them to their old position</param>
+/// <param name="locky">Same as above but for the Y axis. Should be kept the same as the previous parameter</param>
+/// <param name="freeze">Setting this to <b><c>1</c></b> will freeze the player at the end of the animation. <b><c>0</c></b> will not</param>
+/// <param name="time">Timer in milliseconds. For a never-ending loop it should be <b><c>0</c></b></param>
+/// <param name="forcesync">Set to <b><c>1</c></b> to make server sync the animation with all other players in streaming radius. <b><c>2</c></b> works same as <b><c>1</c></b>, but will ONLY apply the animation to streamed-in players, but NOT the actual player being animated (useful for npc animations and persistent animations when players are being streamed) (optional=<b><c>0</c></b>)</param>
+/// <seealso name="ClearAnimations"/>
+/// <seealso name="SetPlayerSpecialAction"/>
+/// <remarks>The <paramref name="forcesync"/> optional parameter, which defaults to <b><c>0</c></b>, in most cases is not needed since players sync animations themselves. The <paramref name="forcesync"/> parameter can force all players who can see <paramref name="playerid"/> to play the animation regardless of whether the player is performing that animation. This is useful in circumstances where the player can't sync the animation themselves. For example, they may be paused.</remarks>
+/// <remarks>An invalid animation library will crash the player's game.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even if the player specified does not exist, or any of the parameters are invalid (e.g. invalid library).</returns>
 native ApplyAnimation(playerid, animlib[], animname[], Float:fDelta, loop, lockx, locky, freeze, time, forcesync = 0);
+
+/// <summary>Clears all animations for the given player (it also cancels all current tasks such as jetpacking,parachuting,entering vehicles, driving (removes player out of vehicle), swimming, etc.. ).</summary>
+/// <param name="playerid">The ID of the player to clear the animations of</param>
+/// <param name="forcesync">Set to <b><c>1</c></b> to force playerid to sync the animation with other players in streaming radius (optional=<b><c>0</c></b>)</param>
+/// <seealso name="ApplyAnimation"/>
+/// <remarks>ClearAnimations doesn't do anything when the animation ends if we pass 1 for the freeze parameter in <a href="#ApplyAnimation">ApplyAnimation</a>.</remarks>
+/// <remarks>Unlike some other ways to remove player from a vehicle, this will also reset the vehicle's velocity to zero, instantly stopping the car. Player will appear on top of the vehicle with the same location as he was in his car seat.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even when the player specified is not connected.</returns>
 native ClearAnimations(playerid, forcesync = 0);
+
+/// <summary>Returns the index of any running applied animations.</summary>
+/// <param name="playerid">ID of the player of whom you want to get the animation index of</param>
+/// <seealso name="GetAnimationName"/>
+/// <remarks>This function was added in <b>SA-MP 0.3b</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>0</c></b> if there is no animation applied.</returns>
 native GetPlayerAnimationIndex(playerid); // return the index of any running applied animations (0 if none are running)
+
+/// <summary>Get the animation library/name for the index.</summary>
+/// <param name="index">The animation index, returned by <a href="#GetPlayerAnimationIndex">GetPlayerAnimationIndex</a></param>
+/// <param name="animlib">String variable that stores the animation library</param>
+/// <param name="len1">Size of the string that stores the animation library</param>
+/// <param name="animname">String variable that stores the animation name</param>
+/// <param name="len2">Size of the string that stores the animation name</param>
+/// <seealso name="GetPlayerAnimationIndex"/>
+/// <remarks>This function was added in <b>SA-MP 0.3b</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> on success, <b><c>0</c></b> on failure.</returns>
 native GetAnimationName(index, animlib[], len1, animname[], len2); // get the animation lib/name for the index
+
+/// <summary>Retrieves a player's current <a href="http://wiki.sa-mp.com/wiki/SpecialActions">special action</a>.</summary>
+/// <param name="playerid">The ID of the player to get the <a href="http://wiki.sa-mp.com/wiki/SpecialActions">special action</a> of</param>
+/// <seealso name="SetPlayerSpecialAction"/>
+/// <seealso name="GetPlayerState"/>
+/// <remarks>
+///   <b>Special actions: (marked with * cannot be set)</b><p/>
+///   <ul>
+///     <li><b><c>0 - SPECIAL_ACTION_NONE</c></b></li>
+///     <li><b><c>2 - SPECIAL_ACTION_USEJETPACK</c></b></li>
+///     <li><b><c>5 - SPECIAL_ACTION_DANCE1</c></b></li>
+///     <li><b><c>6 - SPECIAL_ACTION_DANCE2</c></b></li>
+///     <li><b><c>7 - SPECIAL_ACTION_DANCE3</c></b></li>
+///     <li><b><c>8 - SPECIAL_ACTION_DANCE4</c></b></li>
+///     <li><b><c>10 - SPECIAL_ACTION_HANDSUP</c></b></li>
+///     <li><b><c>11 - SPECIAL_ACTION_USECELLPHONE</c></b></li>
+///     <li><b><c>12 - SPECIAL_ACTION_SITTING *</c></b></li>
+///     <li><b><c>13 - SPECIAL_ACTION_STOPUSECELLPHONE</c></b></li>
+///   </ul>
+///   <b>added in SA-MP 0.3:</b><p/>
+///   <ul>
+///     <li><b><c>1 - SPECIAL_ACTION_DUCK *</c></b> - Detect if the player is crouching.</li>
+///     <li><b><c>3 - SPECIAL_ACTION_ENTER_VEHICLE *</c></b> - Detect if the player is entering a vehicle via an animation.</li>
+///     <li><b><c>4 - SPECIAL_ACTION_EXIT_VEHICLE *</c></b> - Detect if the player is exiting a vehicle via an animation.</li>
+///     <li><b><c>20 - SPECIAL_ACTION_DRINK_BEER</c></b> - Will increase the player's drunk level when used</li>
+///     <li><b><c>21 - SPECIAL_ACTION_SMOKE_CIGGY</c></b> - Will give the player a cigar</li>
+///     <li><b><c>22 - SPECIAL_ACTION_DRINK_WINE</c></b> - Will give the player a wine bottle to get drunk from</li>
+///     <li><b><c>23 - SPECIAL_ACTION_DRINK_SPRUNK</c></b> - Will give the player a sprunk bottle to drink from</li>
+///     <li><b><c>68 - SPECIAL_ACTION_PISSING</c></b> - Will make make the player perform the pissing animation with visible pee.</li>
+///   </ul>
+///   <b>added in SA-MP 0.3e:</b><p/>
+///   <ul>
+///     <li><b><c>24 - SPECIAL_ACTION_CUFFED</c></b> - Will force the player in to cuffs (hands are behind their back) (<b>does not work on CJ skin</b>)</li>
+///   </ul>
+///   <b>added in SA-MP 0.3x:</b><p/>
+///   <ul>
+///     <li><b><c>25 - SPECIAL_ACTION_CARRY</c></b>         - Will apply a 'carrying' animation to the player and make them unable to sprint, jump or punch (<b>does not work on CJ skin</b>)</li>
+///   </ul>
+/// </remarks>
+/// <returns>The <a href="http://wiki.sa-mp.com/wiki/SpecialActions">special action</a> of the player.</returns>
 native GetPlayerSpecialAction(playerid);
+
+/// <summary>This function allows to set players special action.</summary>
+/// <param name="playerid">The player that should perform the action</param>
+/// <param name="actionid">The action that should be performed</param>
+/// <seealso name="GetPlayerSpecialAction"/>
+/// <seealso name="ApplyAnimation"/>
+/// <remarks>Removing jetpacks from players by setting their special action to <b><c>0</c></b> causes the sound to stay until death.</remarks>
+/// <remarks>
+///   <b>Special actions: (marked with * cannot be set)</b><p/>
+///   <ul>
+///     <li><b><c>0 - SPECIAL_ACTION_NONE</c></b></li>
+///     <li><b><c>2 - SPECIAL_ACTION_USEJETPACK</c></b></li>
+///     <li><b><c>5 - SPECIAL_ACTION_DANCE1</c></b></li>
+///     <li><b><c>6 - SPECIAL_ACTION_DANCE2</c></b></li>
+///     <li><b><c>7 - SPECIAL_ACTION_DANCE3</c></b></li>
+///     <li><b><c>8 - SPECIAL_ACTION_DANCE4</c></b></li>
+///     <li><b><c>10 - SPECIAL_ACTION_HANDSUP</c></b></li>
+///     <li><b><c>11 - SPECIAL_ACTION_USECELLPHONE</c></b></li>
+///     <li><b><c>12 - SPECIAL_ACTION_SITTING *</c></b></li>
+///     <li><b><c>13 - SPECIAL_ACTION_STOPUSECELLPHONE</c></b></li>
+///   </ul>
+///   <b>added in SA-MP 0.3:</b><p/>
+///   <ul>
+///     <li><b><c>1 - SPECIAL_ACTION_DUCK *</c></b> - Detect if the player is crouching.</li>
+///     <li><b><c>3 - SPECIAL_ACTION_ENTER_VEHICLE *</c></b> - Detect if the player is entering a vehicle via an animation.</li>
+///     <li><b><c>4 - SPECIAL_ACTION_EXIT_VEHICLE *</c></b> - Detect if the player is exiting a vehicle via an animation.</li>
+///     <li><b><c>20 - SPECIAL_ACTION_DRINK_BEER</c></b> - Will increase the player's drunk level when used</li>
+///     <li><b><c>21 - SPECIAL_ACTION_SMOKE_CIGGY</c></b> - Will give the player a cigar</li>
+///     <li><b><c>22 - SPECIAL_ACTION_DRINK_WINE</c></b> - Will give the player a wine bottle to get drunk from</li>
+///     <li><b><c>23 - SPECIAL_ACTION_DRINK_SPRUNK</c></b> - Will give the player a sprunk bottle to drink from</li>
+///     <li><b><c>68 - SPECIAL_ACTION_PISSING</c></b> - Will make make the player perform the pissing animation with visible pee.</li>
+///   </ul>
+///   <b>added in SA-MP 0.3e:</b><p/>
+///   <ul>
+///     <li><b><c>24 - SPECIAL_ACTION_CUFFED</c></b> - Will force the player in to cuffs (hands are behind their back) (<b>does not work on CJ skin</b>)</li>
+///   </ul>
+///   <b>added in SA-MP 0.3x:</b><p/>
+///   <ul>
+///     <li><b><c>25 - SPECIAL_ACTION_CARRY</c></b>         - Will apply a 'carrying' animation to the player and make them unable to sprint, jump or punch (<b>does not work on CJ skin</b>)</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native SetPlayerSpecialAction(playerid,actionid);
+
+/// <summary>Disables collisions between occupied vehicles for a player.</summary>
+/// <param name="playerid">The ID of the player for whom you want to disable collisions</param>
+/// <param name="disable"><b><c>1</c></b> to disable collisions, <b><c>0</c></b> to enable collisions</param>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.
+/// </returns>
 native DisableRemoteVehicleCollisions(playerid, disable);
 
 // Player world/map related
+
+/// <summary>Sets a checkpoint (red cylinder) for a player. Also shows a red blip on the radar. When players enter a checkpoint, <a href="#OnPlayerEnterCheckpoint">OnPlayerEnterCheckpoint</a> is called and actions can be performed.</summary>
+/// <param name="playerid">The ID of the player for whom to set a checkpoint</param>
+/// <param name="x">The X coordinate to set the checkpoint at</param>
+/// <param name="y">The Y coordinate to set the checkpoint at</param>
+/// <param name="z">The Z coordinate to set the checkpoint at</param>
+/// <param name="size">The size of the checkpoint</param>
+/// <remarks>
+///   If a checkpoint is already set it will use the size of that checkpoint instead of the new one.<p/>
+///   Checkpoints created on server-created objects (<a href="#CreateObject">CreateObject</a>/<a href="#CreatePlayerObject">CreatePlayerObject</a>) will appear down on the 'real' ground, but will still function correctly. A pickup can be used instead.
+/// </remarks>
+/// <remarks>Checkpoints are asynchronous, meaning only one can be shown at a time. To 'stream' checkpoints (only show them when players are close enough), use a checkpoint streamer.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.
+/// </returns>
 native SetPlayerCheckpoint(playerid, Float:x, Float:y, Float:z, Float:size);
+
+/// <summary>Disables (hides/destroys) a player's set checkpoint. Players can only have a single checkpoint set at a time. Checkpoints don't need to be disabled before setting another one.</summary>
+/// <param name="playerid">The ID of the player whose checkpoint to disable</param>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="IsPlayerInCheckpoint"/>
+/// <seealso name="SetPlayerRaceCheckpoint"/>
+/// <seealso name="DisablePlayerRaceCheckpoint"/>
+/// <seealso name="IsPlayerInRaceCheckpoint"/>
+/// <seealso name="OnPlayerEnterCheckpoint"/>
+/// <seealso name="OnPlayerLeaveCheckpoint"/>
+/// <seealso name="OnPlayerEnterRaceCheckpoint"/>
+/// <seealso name="OnPlayerLeaveRaceCheckpoint"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. Success is also returned if the player doesn't have a checkpoint shown already.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native DisablePlayerCheckpoint(playerid);
+
+/// <summary>Creates a race checkpoint. When the player enters it, the <a href="#OnPlayerEnterRaceCheckpoint">OnPlayerEnterRaceCheckpoint</a> callback is called.</summary>
+/// <param name="playerid">The ID of the player to set the checkpoint for</param>
+/// <param name="type">Type of checkpoint. <b><c>0</c></b>-Normal, <b><c>1</c></b>-Finish, <b><c>2</c></b>-Nothing(Only the checkpoint without anything on it), <b><c>3</c></b>-Air normal, <b><c>4</c></b>-Air finish, <b><c>5</c></b>-Air (rotates and stops), <b><c>6</c></b>-Air (increases, decreases and disappears), <b><c>7</c></b>-Air (swings down and up), <b><c>8</c></b>-Air (swings up and down)</param>
+/// <param name="x">X-Coordinate</param>
+/// <param name="y">Y-Coordinate</param>
+/// <param name="z">Z-Coordinate</param>
+/// <param name="nextx">X-Coordinate of the next point, for the arrow facing direction</param>
+/// <param name="nexty">Y-Coordinate of the next point, for the arrow facing direction</param>
+/// <param name="nextz">Z-Coordinate of the next point, for the arrow facing direction</param>
+/// <param name="size">Size (diameter) of the checkpoint</param>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="DisablePlayerCheckpoint"/>
+/// <seealso name="IsPlayerInCheckpoint"/>
+/// <seealso name="DisablePlayerRaceCheckpoint"/>
+/// <seealso name="IsPlayerInRaceCheckpoint"/>
+/// <seealso name="OnPlayerEnterCheckpoint"/>
+/// <seealso name="OnPlayerLeaveCheckpoint"/>
+/// <seealso name="OnPlayerEnterRaceCheckpoint"/>
+/// <seealso name="OnPlayerLeaveRaceCheckpoint"/>
+/// <remarks>If a race checkpoint is already set it will use the size of that checkpoint instead of the new one. </remarks>
+/// <remarks>
+///   Race checkpoints created on server-created objects (<a href="#CreateObject">CreateObject</a>/<a href="#CreatePlayerObject">CreatePlayerObject</a>) will appear down on the 'real' ground, but will still function correctly.<p/>
+///   Race checkpoints are asynchronous, meaning only one can be shown at a time. To 'stream' race checkpoints (only show them when players are close enough), use a race checkpoint streamer.
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player specified does not exist.
+/// </returns>
 native SetPlayerRaceCheckpoint(playerid, type, Float:x, Float:y, Float:z, Float:nextx, Float:nexty, Float:nextz, Float:size);
+
+/// <summary>Disable any initialized race checkpoints for a specific player, since you can only have one at any given time.</summary>
+/// <param name="playerid">The player to disable the current checkpoint for</param>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="DisablePlayerCheckpoint"/>
+/// <seealso name="IsPlayerInCheckpoint"/>
+/// <seealso name="SetPlayerRaceCheckpoint"/>
+/// <seealso name="IsPlayerInRaceCheckpoint"/>
+/// <seealso name="OnPlayerEnterCheckpoint"/>
+/// <seealso name="OnPlayerLeaveCheckpoint"/>
+/// <seealso name="OnPlayerEnterRaceCheckpoint"/>
+/// <seealso name="OnPlayerLeaveRaceCheckpoint"/>
 native DisablePlayerRaceCheckpoint(playerid);
+
+/// <summary>Set the world boundaries for a player. Players can not go out of the boundaries (they will be pushed back in).</summary>
+/// <param name="playerid">The ID of the player to set the world boundaries of</param>
+/// <param name="x_max">The maximum X coordinate the player can go to</param>
+/// <param name="x_min">The minimum X coordinate the player can go to</param>
+/// <param name="y_max">The maximum Y coordinate the player can go to</param>
+/// <param name="y_min">The minimum Y coordinate the player can go to</param>
+/// <seealso name="GangZoneCreate"/>
+/// <remarks>This function does not work if used in <a href="#OnPlayerConnect">OnPlayerConnect</a></remarks>
+/// <remarks>A player's world boundaries can be reset by setting them to <b><c>20000.0</c></b>, <b><c>-20000.0</c></b>, <b><c>20000.0</c></b>, <b><c>-20000.0</c></b>. These are the default values.</remarks>
+/// <remarks>This function doesn't work in interiors!</remarks>
 native SetPlayerWorldBounds(playerid,Float:x_max,Float:x_min,Float:y_max,Float:y_min);
+
+/// <summary>Change the colour of a player's <b>nametag</b> and <b>radar blip</b> for another player.</summary>
+/// <param name="playerid">The player that will see the player's changed blip/nametag color</param>
+/// <param name="showplayerid">The player whose color will be changed</param>
+/// <param name="color">New color. (<b>RGBA</b>)</param>
+/// <seealso name="ShowPlayerMarkers"/>
+/// <seealso name="LimitPlayerMarkerRadius"/>
+/// <seealso name="SetPlayerColor"/>
+/// <seealso name="ShowPlayerNameTagForPlayer"/>
 native SetPlayerMarkerForPlayer(playerid, showplayerid, color);
+
+/// <summary>This functions allows you to toggle the drawing of player nametags, healthbars and armor bars which display above their head. For use of a similar function like this on a global level, <a href="#ShowNameTags">ShowNameTags</a> function.</summary>
+/// <param name="playerid">Player who will see the results of this function</param>
+/// <param name="showplayerid">Player whose name tag will be shown or hidden</param>
+/// <param name="show"><b><c>1</c></b>-show name tag, <b><c>0</c></b>-hide name tag</param>
+/// <seealso name="ShowNameTags"/>
+/// <seealso name="DisableNameTagLOS"/>
+/// <seealso name="SetPlayerMarkerForPlayer"/>
+/// <remarks><a href="#ShowNameTags">ShowNameTags</a> must be set to <b><c>1</c></b> to be able to show name tags with ShowPlayerNameTagForPlayer, that means that in order to be effective you need to <c>ShowPlayerNameTagForPlayer(forplayerid, playerid, 0)</c> ahead of time(<a href="#OnPlayerStreamIn">OnPlayerStreamIn</a> is a good spot).</remarks>
 native ShowPlayerNameTagForPlayer(playerid, showplayerid, show);
 
 #define MAPICON_LOCAL			  0 // displays in the player's local are
@@ -207,47 +1955,361 @@ native ShowPlayerNameTagForPlayer(playerid, showplayerid, show);
 #define MAPICON_LOCAL_CHECKPOINT  2 // displays in the player's local area and has a checkpoint marker
 #define MAPICON_GLOBAL_CHECKPOINT 3 // displays always and has a checkpoint marker
 
+
+/// <summary>Place an icon/marker on a player's map. Can be used to mark locations such as banks and hospitals to players.</summary>
+/// <param name="playerid">The ID of the player to set the map icon for</param>
+/// <param name="iconid">The player's icon ID, ranging from <b><c>0</c></b> to <b><c>99</c></b>. This means there is a maximum of <b><c>100</c></b> map icons. ID can be used in <a href="#RemovePlayerMapIcon">RemovePlayerMapIcon</a></param>
+/// <param name="x">The X coordinate to place the map icon at</param>
+/// <param name="y">The Y coordinate to place the map icon at</param>
+/// <param name="z">The Z coordinate to place the map icon at</param>
+/// <param name="markertype">The icon to set</param>
+/// <param name="color">The color of the icon (<b>RGBA</b>). This should only be used with the square icon (ID: <b><c>0</c></b>)</param>
+/// <param name="style">The style of icon (optional=<b><c>MAPICON_LOCAL</c></b>)</param>
+/// <seealso name="RemovePlayerMapIcon"/>
+/// <seealso name="SetPlayerMarkerForPlayer"/>
+/// <remarks>If you use an invalid marker type, it will create ID <b><c>1</c></b> (White Square). </remarks>
+/// <remarks>If you use an icon ID that is already in use, it will replace the current map icon using that ID. </remarks>
+/// <remarks>Marker type <b><c>1</c></b> (square), <b><c>2</c></b> (player blip), <b><c>4</c></b> (north), and <b><c>56</c></b> (single airstrip blip) will cause your game to crash if you have map legends enabled while viewing the map.</remarks>
+/// <remarks>
+///   <b>Map icon styles:</b><p/>
+///   <ul>
+///     <li><b><c>0 MAPICON_LOCAL</c></b> - close proximity only</li>
+///     <li><b><c>1 MAPICON_GLOBAL</c></b> - show on radar edge as long as in range</li>
+///     <li><b><c>2 MAPICON_LOCAL_CHECKPOINT</c></b> - Close proximity only (with checkpoint)</li>
+///     <li><b><c>3 MAPICON_GLOBAL_CHECKPOINT</c></b> - Show on radar edge as long as in range (with checkpoint)</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. Player is not connected.
+/// </returns>
 native SetPlayerMapIcon(playerid, iconid, Float:x, Float:y, Float:z, markertype, color, style = MAPICON_LOCAL);
+
+/// <summary>Removes a map icon that was set earlier for a player using <a href="#SetPlayerMapIcon">SetPlayerMapIcon</a>.</summary>
+/// <param name="playerid">The ID of the player whose icon to remove</param>
+/// <param name="iconid">The ID of the icon to remove. This is the second parameter of <a href="#SetPlayerMapIcon">SetPlayerMapIcon</a></param>
+/// <seealso name="SetPlayerMapIcon"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute.
+/// </returns>
 native RemovePlayerMapIcon(playerid, iconid);
 
+/// <summary>Enable/Disable the teleporting ability for a player by right-clicking on the map.</summary>
+/// <param name="playerid">The ID of the player to allow teleport</param>
+/// <param name="allow"><b><c>1</c></b> to allow, <b><c>0</c></b> to disallow</param>
+/// <remarks><b>This function, as of 0.3d, is deprecated. Check <a href="#OnPlayerClickMap">OnPlayerClickMap</a>.</b></remarks>
+/// <remarks>This function will work only if <a href="#AllowAdminTeleport">AllowAdminTeleport</a> is enabled, and you have to be an admin.</remarks>
+/// <seealso name="AllowAdminTeleport"/>
 native AllowPlayerTeleport(playerid, allow);
 
 // Player camera
+
+/// <summary>Sets the camera to a specific position for a player.</summary>
+/// <param name="playerid">ID of the player</param>
+/// <param name="x">The X coordinate to place the camera at</param>
+/// <param name="y">The Y coordinate to place the camera at</param>
+/// <param name="z">The Z coordinate to place the camera at</param>
+/// <seealso name="SetPlayerCameraLookAt"/>
+/// <seealso name="SetCameraBehindPlayer"/>
+/// <remarks>You may also have to use <a href="#SetPlayerCameraLookAt">SetPlayerCameraLookAt</a> with this function in order to work properly.</remarks>
+/// <remarks>Use <a href="#SetCameraBehindPlayer">SetCameraBehindPlayer</a> to reset the camera to behind the player.</remarks>
+/// <remarks>Using the camera functions directly after enabling spectator mode doesn't work.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified doesn't exist.
+/// </returns>
 native SetPlayerCameraPos(playerid,Float:x, Float:y, Float:z);
 
 #define CAMERA_CUT	2
 #define CAMERA_MOVE 1
 
+
+/// <summary>Set the direction a player's camera looks at. Generally meant to be used in combination with <a href="#SetPlayerCameraPos">SetPlayerCameraPos</a>.</summary>
+/// <param name="playerid">The ID of the player whose camera to set</param>
+/// <param name="x">The X coordinate for the player's camera to look at</param>
+/// <param name="y">The Y coordinate for the player's camera to look at</param>
+/// <param name="z">The Z coordinate for the player's camera to look at</param>
+/// <param name="cut">The style of the change. Can be used to interpolate (change slowly) from old pos to new pos using <b><c>CAMERA_MOVE</c></b>. Added in <b>0.3e</b>. Leave out for older versions (optional=<b><c>CAMERA_CUT</c></b>)</param>
+/// <seealso name="SetPlayerCameraPos"/>
+/// <seealso name="SetCameraBehindPlayer"/>
+/// <seealso name="GetPlayerCameraPos"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>Using the camera functions directly after enabling spectator mode doesn't work.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player specified does not exist.
+/// </returns>
 native SetPlayerCameraLookAt(playerid, Float:x, Float:y, Float:z, cut = CAMERA_CUT);
+
+/// <summary>Restore the camera to a place behind the player, after using a function like <a href="#SetPlayerCameraPos">SetPlayerCameraPos</a>.</summary>
+/// <param name="playerid">The player you want to restore the camera for</param>
+/// <seealso name="SetPlayerCameraPos"/>
+/// <seealso name="SetPlayerCameraLookAt"/>
 native SetCameraBehindPlayer(playerid);
+
+/// <summary>Get the position of the player's camera.</summary>
+/// <param name="playerid">The ID of the player to get the camera position of</param>
+/// <param name="x">A float variable to store the X coordinate in, passed by reference</param>
+/// <param name="y">A float variable to store the Y coordinate in, passed by reference</param>
+/// <param name="z">A float variable to store the Z coordinate in, passed by reference</param>
+/// <seealso name="SetPlayerCameraPos"/>
+/// <seealso name="GetPlayerCameraZoom"/>
+/// <seealso name="GetPlayerCameraAspectRatio"/>
+/// <seealso name="GetPlayerCameraMode"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>Player's camera positions are only updated once a second, <b>unless aiming</b>.</remarks>
+/// <remarks>It is recommended to set a 1 second timer if you wish to take action that relies on a player's camera position.</remarks>
 native GetPlayerCameraPos(playerid, &Float:x, &Float:y, &Float:z);
+
+/// <summary>This function will return the current direction of player's aiming in 3-D space, the coords are relative to the camera position, see <a href="#GetPlayerCameraPos">GetPlayerCameraPos</a>.</summary>
+/// <param name="playerid">The ID of the player you want to obtain the camera front vector of</param>
+/// <param name="x">A float to store the X coordinate, passed by reference</param>
+/// <param name="y">A float to store the Y coordinate, passed by reference</param>
+/// <param name="z">A float to store the Z coordinate, passed by reference</param>
+/// <seealso name="GetPlayerCameraPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>In <b>0.3a</b> the camera front vector is only obtainable when player is inside a rhino, S.W.A.T tank, fire truck, or on foot. </remarks>
+/// <remarks>Since <b>0.3b</b> the camera data can be obtained when the player is in any vehicle or on foot. </remarks>
+/// <returns>The position is stored in the specified variables.</returns>
 native GetPlayerCameraFrontVector(playerid, &Float:x, &Float:y, &Float:z);
+
+/// <summary>Returns the current GTA camera mode for the requested player. The camera modes are useful in determining whether a player is aiming, doing a passenger driveby etc.</summary>
+/// <param name="playerid">The ID of the player whose camera mode to retrieve</param>
+/// <seealso name="GetPlayerCameraPos"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <seealso name="SetPlayerCameraPos"/>
+/// <seealso name="SetPlayerCameraLookAt"/>
+/// <seealso name="SetCameraBehindPlayer"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c R3</b> and will not work in earlier versions!</remarks>
+/// <returns>The camera mode as an integer (or <b><c>-1</c></b> if player is not connected).</returns>
 native GetPlayerCameraMode(playerid);
+
+/// <summary>Toggle camera targeting functions for a player. Disabled by default to save bandwidth.</summary>
+/// <param name="playerid">The ID of the player to toggle camera targeting functions for</param>
+/// <param name="enable"><b><c>1</c></b> to enable camera targeting functions and <b><c>0</c></b> to disable them</param>
+/// <seealso name="GetPlayerCameraTargetVehicle"/>
+/// <seealso name="GetPlayerCameraTargetPlayer"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player is not connected.
+/// </returns>
 native EnablePlayerCameraTarget(playerid, enable);
+
+/// <summary>Allows you to retrieve the ID of the object the player is looking at.</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="GetPlayerCameraTargetVehicle"/>
+/// <seealso name="GetPlayerCameraTargetPlayer"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function is disabled by default to save bandwidth. Use <a href="#EnablePlayerCameraTarget">EnablePlayerCameraTarget</a> to enable it for each player.</remarks>
+/// <returns>The ID of the object playerid is looking at. If <b><c>INVALID_OBJECT_ID (65535)</c></b> is returned, playerid isn't looking at any object.</returns>
 native GetPlayerCameraTargetObject(playerid);
+
+/// <summary>Get the ID of the vehicle the player is looking at.</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="GetPlayerCameraTargetPlayer"/>
+/// <seealso name="GetPlayerCameraTargetObject"/>
+/// <seealso name="EnablePlayerCameraTarget"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function is disabled by default to save bandwidth. Use <a href="#EnablePlayerCameraTarget">EnablePlayerCameraTarget</a> to enable it for each player.</remarks>
+/// <remarks>This function can (obviously) only return one vehicle ID at a time, while the player may be looking at multiple. It generally seems to detect the closest vehicle first.</remarks>
+/// <returns>The vehicle ID of the vehicle the player is looking at. <b><c>INVALID_VEHICLE_ID</c></b> if none.</returns>
 native GetPlayerCameraTargetVehicle(playerid);
+
+/// <summary>Allows you to retrieve the ID of the player the playerid is looking at.</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="GetPlayerCameraTargetActor"/>
+/// <seealso name="GetPlayerCameraTargetVehicle"/>
+/// <seealso name="GetPlayerCameraTargetObject"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function is disabled by default to save bandwidth. Use <a href="#EnablePlayerCameraTarget">EnablePlayerCameraTarget</a> to enable it for each player.</remarks>
+/// <remarks>Do not confuse this function with <a href="#GetPlayerTargetPlayer">GetPlayerTargetPlayer</a>. <a href="#GetPlayerTargetPlayer">GetPlayerTargetPlayer</a> returns the ID of the player playerid is aming at (with a weapon). <a href="#GetPlayerCameraTargetPlayer">GetPlayerCameraTargetPlayer</a> returns the ID of the player playerid is looking at (reference point is the <b>center of the screen</b>).</remarks>
+/// <returns>The ID of the player the playerid is looking at.</returns>
 native GetPlayerCameraTargetPlayer(playerid);
+
+/// <summary>Allows you to retrieve the ID of the actor the player is looking at (if any).</summary>
+/// <param name="playerid">The ID of the player to get the target actor of</param>
+/// <seealso name="GetPlayerTargetActor"/>
+/// <seealso name="GetPlayerCameraTargetPlayer"/>
+/// <seealso name="GetPlayerCameraTargetVehicle"/>
+/// <seealso name="GetPlayerCameraTargetObject"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function is disabled by default to save bandwidth. Use <a href="#EnablePlayerCameraTarget">EnablePlayerCameraTarget</a> to enable it for each player.</remarks>
+/// <remarks>This function only tells you which actor (if any) the player is <b>looking</b> at. To find out if they are <b>aiming</b> at them, you need to use <a href="#GetPlayerTargetActor">GetPlayerTargetActor</a>.</remarks>
+/// <returns>The ID of the actor the player is looking at.</returns>
 native GetPlayerCameraTargetActor(playerid);
+
+/// <summary>Retrieves the aspect ratio of a player's camera.</summary>
+/// <param name="playerid">The ID of the player to get the camera aspect ratio of</param>
+/// <seealso name="GetPlayerCameraZoom"/>
+/// <seealso name="GetPlayerCameraPos"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions! </remarks>
+/// <remarks>The return value of this function represents the value of the "widescreen" option in the game's display settings, not the actual aspect ratio of the player's display.</remarks>
+/// <returns>The aspect ratio of the player's camera, as a float. The aspect ratio can be one of three values: 4:3 (<b><c>1.3333334</c></b>, <b><c>Float:0x3FAAAAAB</c></b>) when widescreen is turned off, 5:4 (<b><c>1.2470589</c></b>, <b><c>Float:0x3F9F9FA0</c></b>) when letterbox mode is turned on, and 16:9 (<b><c>1.7764707</c></b>, <b><c>Float:0x3FE36364</c></b>) when widescreen is turned on regardless of the letterbox mode.</returns>
 native Float:GetPlayerCameraAspectRatio(playerid);
+
+/// <summary>Retrieves the game camera zoom level for a given player.</summary>
+/// <param name="playerid">The ID of the player to get the camera zoom level of</param>
+/// <seealso name="GetPlayerCameraAspectRatio"/>
+/// <seealso name="GetPlayerCameraPos"/>
+/// <seealso name="GetPlayerCameraFrontVector"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <remarks>This retrieves the zoom level of the GAME camera, not the camera WEAPON.</remarks>
+/// <returns>The player's camera zoom level (camera, sniper etc.), a float.</returns>
 native Float:GetPlayerCameraZoom(playerid);
+
+/// <summary>You can use this function to attach the player camera to objects.</summary>
+/// <param name="playerid">The ID of the player which will have your camera attached on object</param>
+/// <param name="objectid">The object id which you want to attach the player camera</param>
+/// <seealso name="AttachCameraToPlayerObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>You need to create the object first, before attempting to attach a player camera for that.</remarks>
 native AttachCameraToObject(playerid, objectid);
+
+/// <summary>Attaches a player's camera to a player-object. The player is able to move their camera while it is attached to an object. Can be used with MovePlayerObject and AttachPlayerObjectToVehicle.</summary>
+/// <param name="playerid">The ID of the player which will have their camera attached to a player-object</param>
+/// <param name="playerobjectid">The ID of the player-object to which the player's camera will be attached</param>
+/// <seealso name="AttachCameraToObject"/>
+/// <seealso name="SetPlayerCameraPos"/>
+/// <seealso name="SetPlayerCameraLookAt"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>The player-object must be created before attempting to attach the player's camera to it.</remarks>
 native AttachCameraToPlayerObject(playerid, playerobjectid);
+
+
+/// <summary>Move a player's camera from one position to another, within the set time. Useful for scripted cut scenes.</summary>
+/// <param name="playerid">The ID of the player the camera should be moved for</param>
+/// <param name="FromX">The X position the camera should start to move from</param>
+/// <param name="FromY">The Y position the camera should start to move from</param>
+/// <param name="FromZ">The Z position the camera should start to move from</param>
+/// <param name="ToX">The X position the camera should move to</param>
+/// <param name="ToY">The Y position the camera should move to</param>
+/// <param name="ToZ">The Z position the camera should move to</param>
+/// <param name="time">Time in milliseconds</param>
+/// <param name="cut">The jumpcut to use. Set to <b><c>CAMERA_MOVE</c></b> for a smooth movement (optional=<b><c>CAMERA_CUT</c></b>)</param>
+/// <seealso name="InterpolateCameraLookAt"/>
+/// <seealso name="SetPlayerCameraPos"/>
+/// <seealso name="SetPlayerCameraLookAt"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>Use <b><c>TogglePlayerSpectating</c></b> to make objects stream in for the player while the camera is moving. You can reset the camera behind the player with <b><c>SetCameraBehindPlayer</c></b>.</remarks>
 native InterpolateCameraPos(playerid, Float:FromX, Float:FromY, Float:FromZ, Float:ToX, Float:ToY, Float:ToZ, time, cut = CAMERA_CUT);
+
+/// <summary>Interpolate a player's camera's 'look at' point between two coordinates with a set speed. Can be be used with <a href="#InterpolateCameraPos">InterpolateCameraPos</a>.</summary>
+/// <param name="playerid">The ID of the player the camera should be moved for</param>
+/// <param name="FromX">The X position the camera should start to move from</param>
+/// <param name="FromY">The Y position the camera should start to move from</param>
+/// <param name="FromZ">The Z position the camera should start to move from</param>
+/// <param name="ToX">The X position the camera should move to</param>
+/// <param name="ToY">The Y position the camera should move to</param>
+/// <param name="ToZ">The Z position the camera should move to</param>
+/// <param name="time">Time in milliseconds to complete interpolation</param>
+/// <param name="cut">The 'jumpcut' to use. Set to <b><c>CAMERA_MOVE</c></b> for interpolation (optional=<b><c>CAMERA_CUT</c></b>)</param>
+/// <seealso name="InterpolateCameraPos"/>
+/// <seealso name="SetPlayerCameraLookAt"/>
+/// <seealso name="SetPlayerCameraPos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>Use <b><c>TogglePlayerSpectating</c></b> to make objects stream in for the player while the camera is moving. You can reset the camera behind the player with <b><c>SetCameraBehindPlayer</c></b>.</remarks>
 native InterpolateCameraLookAt(playerid, Float:FromX, Float:FromY, Float:FromZ, Float:ToX, Float:ToY, Float:ToZ, time, cut = CAMERA_CUT);
 
 // Player conditionals
+
+/// <summary>Checks if a player is connected (if an ID is taken by a connected player).</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="IsPlayerAdmin"/>
+/// <seealso name="OnPlayerConnect"/>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <remarks>This function can be omitted in a lot of cases. Many other functions already have some sort of connection check built in.</remarks>
+/// <returns><b><c>1</c></b> if the player is connected, <b><c>0</c></b> if not.</returns>
 native IsPlayerConnected(playerid);
+
+/// <summary>Checks if a player is in a specific vehicle.</summary>
+/// <param name="playerid">ID of the player</param>
+/// <param name="vehicleid">ID of the vehicle</param>
+/// <seealso name="IsPlayerInAnyVehicle"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <returns><b><c>1</c></b> if the player is in the vehicle, <b><c>0</c></b> if not.</returns>
 native IsPlayerInVehicle(playerid, vehicleid);
+
+/// <summary>Check if a player is inside any vehicle (as a driver or passenger).</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="IsPlayerInVehicle"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <returns><b><c>1</c></b> if the player is in a vehicle, <b><c>0</c></b> if not.</returns>
 native IsPlayerInAnyVehicle(playerid);
+
+/// <summary>Check if the player is currently inside a checkpoint, this could be used for properties or teleport points for example.</summary>
+/// <param name="playerid">The player you want to know the status of</param>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="DisablePlayerCheckpoint"/>
+/// <seealso name="SetPlayerRaceCheckpoint"/>
+/// <seealso name="DisablePlayerRaceCheckpoint"/>
+/// <seealso name="IsPlayerInRaceCheckpoint"/>
+/// <seealso name="OnPlayerEnterCheckpoint"/>
+/// <seealso name="OnPlayerLeaveCheckpoint"/>
+/// <seealso name="OnPlayerEnterRaceCheckpoint"/>
+/// <seealso name="OnPlayerLeaveRaceCheckpoint"/>
+/// <returns><b><c>0</c></b> if player isn't in his checkpoint else <b><c>1</c></b>.</returns>
 native IsPlayerInCheckpoint(playerid);
+
+/// <summary>Check if the player is inside their current set race checkpoint (<a href="#SetPlayerRaceCheckpoint">SetPlayerRaceCheckpoint</a>).</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="DisablePlayerCheckpoint"/>
+/// <seealso name="IsPlayerInCheckpoint"/>
+/// <seealso name="SetPlayerRaceCheckpoint"/>
+/// <seealso name="DisablePlayerRaceCheckpoint"/>
+/// <seealso name="OnPlayerEnterCheckpoint"/>
+/// <seealso name="OnPlayerLeaveCheckpoint"/>
+/// <seealso name="OnPlayerEnterRaceCheckpoint"/>
+/// <seealso name="OnPlayerLeaveRaceCheckpoint"/>
+/// <returns><b><c>1</c></b> is the player is in a race checkpoint, <b><c>0</c></b> if not.</returns>
 native IsPlayerInRaceCheckpoint(playerid);
 
 // Virtual Worlds
+
+/// <summary>Set the virtual world of a player. They can only see other players or vehicles that are in that same world.</summary>
+/// <param name="playerid">The ID of the player you want to set the virtual world of</param>
+/// <param name="worldid">The virtual world ID to put the player in</param>
+/// <seealso name="GetPlayerVirtualWorld"/>
+/// <seealso name="SetVehicleVirtualWorld"/>
+/// <remarks>The default virtual world is <b><c>0</c></b></remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.
+/// </returns>
 native SetPlayerVirtualWorld(playerid, worldid);
+
+/// <summary>Retrieves the current virtual world the player is in.</summary>
+/// <param name="playerid">The ID of the player to get the virtual world of</param>
+/// <seealso name="SetPlayerVirtualWorld"/>
+/// <seealso name="GetVehicleVirtualWorld"/>
+/// <seealso name="GetPlayerInterior"/>
+/// <returns>The ID of the virtual world the player is currently in.</returns>
 native GetPlayerVirtualWorld(playerid);
 
 // Insane Stunts
+
+/// <summary>Toggle stunt bonuses for a player. Enabled by default.</summary>
+/// <param name="playerid">The ID of the player to toggle stunt bonuses for</param>
+/// <param name="enable"><b><c>1</c></b> to enable stunt bonuses and <b><c>0</c></b> to disable them</param>
+/// <seealso name="EnableStuntBonusForAll"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player is not connected.
+/// </returns>
 native EnableStuntBonusForPlayer(playerid, enable);
+
+/// <summary>Enables or disables stunt bonuses for all players. If enabled, players will receive monetary rewards when performing a stunt in a vehicle (e.g. a wheelie).</summary>
+/// <param name="enable"><b><c>1</c></b> to enable stunt bonuses or <b><c>0</c></b> to disable them</param>
+/// <seealso name="EnableStuntBonusForPlayer"/>
 native EnableStuntBonusForAll(enable);
 
 // Spectating
@@ -255,8 +2317,55 @@ native EnableStuntBonusForAll(enable);
 #define SPECTATE_MODE_FIXED		2
 #define SPECTATE_MODE_SIDE		3
 
+
+/// <summary>Toggle whether a player is in spectator mode or not. While in spectator mode a player can spectate (watch) other players and vehicles. After using this function, either <a href="#PlayerSpectatePlayer">PlayerSpectatePlayer</a> or <a href="#PlayerSpectateVehicle">PlayerSpectateVehicle</a> needs to be used.</summary>
+/// <param name="playerid">The ID of the player who should spectate</param>
+/// <param name="toggle"><b><c>1</c></b> to enable spectating and <b><c>0</c></b> to disable</param>
+/// <seealso name="PlayerSpectatePlayer"/>
+/// <seealso name="PlayerSpectateVehicle"/>
+/// <remarks>If the player is not loaded in before setting the spectate status to false, the connection can be closed unexpectedly.</remarks>
+/// <remarks>When spectator mode is disabled, <a href="#OnPlayerSpawn">OnPlayerSpawn</a> will automatically be called, if you wish to restore player to state before spectating, you will have to handle that in <a href="#OnPlayerSpawn">OnPlayerSpawn</a>. Note also, that player can also go to class selection before if they used F4 during spectate, a player also CAN die in spectate mode due to various glitches.</remarks>
+/// <remarks>When a player is in spectate mode their HUD is hidden, making it useful for setting a player's camera without the HUD. Also, objects near the player's camera will be streamed in, making this useful for interpolating cameras.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player does not exist.
+/// </returns>
 native TogglePlayerSpectating(playerid, toggle);
+
+/// <summary>Makes a player spectate (watch) another player.</summary>
+/// <param name="playerid">The ID of the player that will spectate</param>
+/// <param name="targetplayerid">The ID of the player that should be spectated</param>
+/// <param name="mode">The mode to spectate with (optional=<b><c>SPECTATE_MODE_NORMAL</c></b>)</param>
+/// <seealso name="PlayerSpectateVehicle"/>
+/// <seealso name="TogglePlayerSpectating"/>
+/// <remarks>Order is CRITICAL! Ensure that you use <a href="#TogglePlayerSpectating">TogglePlayerSpectating</a> before <a href="#PlayerSpectatePlayer">PlayerSpectatePlayer</a>. </remarks>
+/// <remarks>playerid and targetplayerid's virtual world and interior must be the same for this function to work properly. </remarks>
+/// <remarks>
+///   <b>Spectate modes:</b><p/>
+///   <ul>
+///     <li><b><c>SPECTATE_MODE_NORMAL</c></b> - normal spectate mode (third person point of view). Camera can not be changed.</li>
+///     <li><b><c>SPECTATE_MODE_FIXED </c></b> - use SetPlayerCameraPos after this to position the player's camera, and it will track the player/vehicle set with PlayerSpectatePlayer/PlayerSpectateVehicle.</li>
+///     <li><b><c>SPECTATE_MODE_SIDE</c></b> - the camera will be attached to the side of the player/vehicle (like when you're in first-person camera on a bike and you do a wheelie).</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. One of the players specified does not exist.
+/// </returns>
 native PlayerSpectatePlayer(playerid, targetplayerid, mode = SPECTATE_MODE_NORMAL);
+
+/// <summary>Sets a player to spectate another vehicle. Their camera will be attached to the vehicle as if they are driving it.</summary>
+/// <param name="playerid">The ID of the player who should spectate a vehicle</param>
+/// <param name="targetvehicleid">The ID of the vehicle the player should spectate</param>
+/// <param name="mode">The spectate mode. Can generally be left blank as it defaults to 'normal'</param>
+/// <seealso name="PlayerSpectatePlayer"/>
+/// <seealso name="TogglePlayerSpectating"/>
+/// <remarks>Order is CRITICAL! Ensure that you use <a href="#TogglePlayerSpectating">TogglePlayerSpectating</a> before <a href="#PlayerSpectatePlayer">PlayerSpectatePlayer</a>. </remarks>
+/// <remarks>playerid and targetvehicleid have to be in the same interior for this function to work properly. </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. Note that success is reported if the player is not in spectator mode (<a href="#TogglePlayerSpectating">TogglePlayerSpectating</a>), but nothing will happen. <a href="#TogglePlayerSpectating">TogglePlayerSpectating</a> MUST be used first.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player, vehicle, or both don't exist.
+/// </returns>
 native PlayerSpectateVehicle(playerid, targetvehicleid, mode = SPECTATE_MODE_NORMAL);
 
 // Recording for NPC playback
@@ -264,11 +2373,54 @@ native PlayerSpectateVehicle(playerid, targetvehicleid, mode = SPECTATE_MODE_NOR
 #define PLAYER_RECORDING_TYPE_DRIVER	1
 #define PLAYER_RECORDING_TYPE_ONFOOT	2
 
+
+/// <summary>Starts recording a player's movements to a file, which can then be reproduced by an NPC.</summary>
+/// <param name="playerid">The ID of the player to record</param>
+/// <param name="recordtype">The type of recording</param>
+/// <param name="recordname">The name of the file which will hold the recorded data. It will be saved in the scriptfiles directory, with an automatically added .rec extension, you will need to move the file to npcmodes/recordings to use for playback</param>
+/// <seealso name="StopRecordingPlayerData"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native StartRecordingPlayerData(playerid, recordtype, recordname[]);
+
+/// <summary>Stops all the recordings that had been started with <a href="#StartRecordingPlayerData">StartRecordingPlayerData</a> for a specific player.</summary>
+/// <param name="playerid">The player you want to stop the recordings of</param>
+/// <seealso name="StartRecordingPlayerData"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native StopRecordingPlayerData(playerid);
 
+/// <summary>Display the cursor and allow the player to select a textdraw.</summary>
+/// <param name="playerid">The ID of the player that should be able to select a textdraw</param>
+/// <param name="hovercolor">The color of the textdraw when hovering over with mouse (<b>RGBA</b>)</param>
+/// <seealso name="CancelSelectTextDraw"/>
+/// <seealso name="TextDrawSetSelectable"/>
+/// <seealso name="PlayerTextDrawSetSelectable"/>
+/// <seealso name="OnPlayerClickTextDraw"/>
+/// <seealso name="OnPlayerClickPlayerTextDraw"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks><a href="#TextDrawSetSelectable">TextDrawSetSelectable</a> or <a href="#PlayerTextDrawSetSelectable">PlayerTextDrawSetSelectable</a> MUST be used first, to allow a textdraw to be selectable.</remarks>
+/// <remarks>It is the TEXT which will be highlighted when hovered over, NOT the box (if one is shown).</remarks>
 native SelectTextDraw(playerid, hovercolor); // enables the mouse so the player can select a textdraw
+
+/// <summary>Cancel textdraw selection with the mouse.</summary>
+/// <param name="playerid">The ID of the player that should be the textdraw selection disabled</param>
+/// <seealso name="SelectTextDraw"/>
+/// <seealso name="TextDrawSetSelectable"/>
+/// <seealso name="OnPlayerClickTextDraw"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function calls <a href="#OnPlayerClickTextDraw">OnPlayerClickTextDraw</a> with <b><c>INVALID_TEXT_DRAW</c></b> (<b><c>65535</c></b>). Using this function inside <a href="#OnPlayerClickTextDraw">OnPlayerClickTextDraw</a> without catching this case will cause clients to go into an infinite loop.</remarks>
 native CancelSelectTextDraw(playerid);	// cancel textdraw selection with the mouse
 
 // Explosion
+
+/// <summary>Creates an explosion that is only visible to a single player. This can be used to isolate explosions from other players or to make them only appear in specific <a href="http://wiki.sa-mp.com/wiki/SetPlayerVirtualWorld">virtual worlds</a>.</summary>
+/// <param name="playerid">The ID of the player to create the explosion for</param>
+/// <param name="X">The X coordinate of the explosion</param>
+/// <param name="Y">The Y coordinate of the explosion</param>
+/// <param name="Z">The Z coordinate of the explosion</param>
+/// <param name="type">The explosion type</param>
+/// <param name="Radius">The radius of the explosion</param>
+/// <seealso name="CreateExplosion"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z R2-2</b> and will not work in earlier versions!</remarks>
+/// <remarks>There is a limit as to how many explosions can be seen at once by a player. This is roughly 10.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even if the function failed to excute (player doesn't exist, invalid radius, or invalid explosion type).</returns>
 native CreateExplosionForPlayer(playerid, Float:X, Float:Y, Float:Z, type, Float:Radius);

--- a/a_players.inc
+++ b/a_players.inc
@@ -376,7 +376,10 @@ native SetPlayerScore(playerid,score);
 /// <returns>The player's score.</returns>
 native GetPlayerScore(playerid);
 
-/// <summary>Checks the player's level of drunkenness. If the level is less than <b><c>2000</c></b>, the player is sober. The player's level of drunkness goes down slowly automatically (1 level per frame) but will always reach <b><c>2000</c></b> at the end (in <b>0.3b</b> it will stop at <b><c>0</c></b>). The higher drunkenness levels affect the player's camera, and the car driving handling. The level of drunkenness increases when the player drinks from a bottle (You can use <a href="#SetPlayerSpecialAction">SetPlayerSpecialAction</a> to give them bottles).</summary>
+/// <summary>
+///   Checks the player's level of drunkenness. If the level is less than <b><c>2000</c></b>, the player is sober. The player's level of drunkness goes down slowly automatically (1 level per frame) but will always reach <b><c>2000</c></b> at the end (in <b>0.3b</b> it will stop at <b><c>0</c></b>).
+///   The higher drunkenness levels affect the player's camera, and the car driving handling. The level of drunkenness increases when the player drinks from a bottle (You can use <a href="#SetPlayerSpecialAction">SetPlayerSpecialAction</a> to give them bottles).
+/// </summary>
 /// <param name="playerid">The player you want to check the drunkenness level of</param>
 /// <seealso name="SetPlayerDrunkLevel"/>
 /// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>

--- a/a_samp.inc
+++ b/a_samp.inc
@@ -54,43 +54,432 @@
 // --------------------------------------------------
 
 // Util
+
+/// <summary>Prints a string to the server console (not in-game chat) and logs (server_log.txt).</summary>
+/// <param name="string">The string to print</param>
+/// <seealso name="printf"/>
 native print(const string[]);
+
+/// <summary>Outputs a formatted string on the console (the server window, not the in-game chat).</summary>
+/// <param name="format">The format string</param>
+/// <param name="">Indefinite number of arguments of any tag</param>
+/// <seealso name="print"/>
+/// <seealso name="format"/>
+/// <remarks>The format string or its output should not exceed 1024 characters. Anything beyond that length can lead to a server to crash.</remarks>
+/// <remarks>This function doesn't support <a href="#strpack">packed</a> strings.</remarks>
+/// <remarks>
+///   <b>Format Specifiers:</b><p/>
+///   <ul>
+///     <li><b><c>%i</c></b> - integer (whole number)</li>
+///     <li><b><c>%d</c></b> - integer (whole number).</li>
+///     <li><b><c>%s</c></b> - string</li>
+///     <li><b><c>%f</c></b> - floating-point number (Float: tag)</li>
+///     <li><b><c>%c</c></b> - ASCII character</li>
+///     <li><b><c>%x</c></b> - hexadecimal number</li>
+///     <li><b><c>%b</c></b> - binary number</li>
+///     <li><b><c>%%</c></b> - literal <b><c>%</c></b></li>
+///     <li><b><c>%q</c></b> - escape a text for SQLite. (Added in <b>0.3.7 R2</b>)</li>
+///   </ul>
+/// </remarks>
+/// <remarks>The values for the placeholders follow in the exact same order as parameters in the call. For example, <b><c>"I am %i years old"</c></b> - the <b><c>%i</c></b> will be replaced with an Integer variable, which is the person's age.</remarks>
+/// <remarks>You may optionally put a number between the <b><c>%</c></b> and the letter of the placeholder code. This number indicates the field width; if the size of the parameter to print at the position of the placeholder is smaller than the field width, the field is expanded with spaces. To cut the number of decimal places beeing shown of a float, you can add <b><c>.&lt;max number&gt;</c></b> between the <b><c>%</c></b> and the <b><c>f</c></b>. (example: <b><c>%.2f</c></b>)</remarks>
 native printf(const format[], {Float,_}:...);
+
+/// <summary>Formats a string to include variables and other strings inside it.</summary>
+/// <param name="output">The string to output the result to</param>
+/// <param name="len">The maximum length output can contain</param>
+/// <param name="format">The format string</param>
+/// <param name="">Indefinite number of arguments of any tag</param>
+/// <seealso name="print"/>
+/// <seealso name="printf"/>
+/// <remarks>This function doesn't support <a href="#strpack">packed strings</a>.</remarks>
+/// <remarks>
+///   <b>Format Specifiers:</b><p/>
+///   <ul>
+///     <li><b><c>%i</c></b> - integer (whole number)</li>
+///     <li><b><c>%d</c></b> - integer (whole number).</li>
+///     <li><b><c>%s</c></b> - string</li>
+///     <li><b><c>%f</c></b> - floating-point number (Float: tag)</li>
+///     <li><b><c>%c</c></b> - ASCII character</li>
+///     <li><b><c>%x</c></b> - hexadecimal number</li>
+///     <li><b><c>%b</c></b> - binary number</li>
+///     <li><b><c>%%</c></b> - literal <b><c>%</c></b></li>
+///     <li><b><c>%q</c></b> - escape a text for SQLite. (Added in <b>0.3.7 R2</b>)</li>
+///   </ul>
+/// </remarks>
+/// <remarks>The values for the placeholders follow in the exact same order as parameters in the call. For example, <b><c>"I am %i years old"</c></b> - the <b><c>%i</c></b> will be replaced with an Integer variable, which is the person's age.</remarks>
+/// <remarks>You may optionally put a number between the <b><c>%</c></b> and the letter of the placeholder code. This number indicates the field width; if the size of the parameter to print at the position of the placeholder is smaller than the field width, the field is expanded with spaces. To cut the number of decimal places beeing shown of a float, you can add <b><c>.&lt;max number&gt;</c></b> between the <b><c>%</c></b> and the <b><c>f</c></b>. (example: <b><c>%.2f</c></b>)</remarks>
 native format(output[], len, const format[], {Float,_}:...);
+
+/// <summary>This function sends a message to a specific player with a chosen color in the chat. The whole line in the chatbox will be in the set color unless color embedding is used (since <b><c>0.3c</c></b>).</summary>
+/// <param name="playerid">The ID of the player to display the message to</param>
+/// <param name="color">The color of the message (<b>RGBA</b>)</param>
+/// <param name="message">The text that will be displayed <b>(max 144 characters)</b></param>
+/// <seealso name="SendClientMessageToAll"/>
+/// <seealso name="SendPlayerMessageToPlayer"/>
+/// <seealso name="SendPlayerMessageToAll"/>
+/// <remarks>If a message is longer than 144 characters, it will not be sent. Truncation can be used to prevent this. Displaying a message on multiple lines will also solve this issue. </remarks>
+/// <remarks>Avoid using the percent sign (or format specifiers) in the actual message text without properly escaping it (like <b><c>%%</c></b>). It will result in crashes otherwise. </remarks>
+/// <remarks>You can use color embedding for multiple colors in the message. </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. Success is reported when the string is over 144 characters, but the message won't be sent.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player is not connected.
+/// </returns>
 native SendClientMessage(playerid, color, const message[]);
+
+/// <summary>Displays a message in chat to all players. This is a multi-player equivalent of <a href="#SendClientMessage">SendClientMessage</a>.</summary>
+/// <param name="color">The color of the message (<b>RGBA</b>)</param>
+/// <param name="message">The message to show (<b>max 144 characters</b>)</param>
+/// <seealso name="SendClientMessage"/>
+/// <seealso name="SendPlayerMessageToAll"/>
+/// <remarks>Avoid using format specifiers in your messages without formatting the string that is sent. It will result in crashes otherwise.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>.</returns>
 native SendClientMessageToAll(color, const message[]);
+
+/// <summary>Sends a message in the name of a player to another player on the server. The message will appear in the chat box but can only be seen by the user specified with <paramref name="playerid"/>. The line will start with the sender's name in their color, followed by the message in white.</summary>
+/// <param name="playerid">The ID of the player who will receive the message</param>
+/// <param name="senderid">The sender's ID. If invalid, the message will not be sent</param>
+/// <param name="message">The message that will be sent</param>
+/// <seealso name="SendPlayerMessageToAll"/>
+/// <seealso name="SendClientMessage"/>
+/// <seealso name="SendClientMessageToAll"/>
+/// <seealso name="OnPlayerText"/>
+/// <remarks>Avoid using format specifiers in your messages without formatting the string that is sent. It will result in crashes otherwise.</remarks>
 native SendPlayerMessageToPlayer(playerid, senderid, const message[]);
+
+/// <summary>Sends a message in the name of a player to all other players on the server. The line will start with the sender's name in their color, followed by the message in white.</summary>
+/// <param name="senderid">The ID of the sender. If invalid, the message will not be sent</param>
+/// <param name="message">The message that will be sent</param>
+/// <seealso name="SendPlayerMessageToPlayer"/>
+/// <seealso name="SendClientMessageToAll"/>
+/// <seealso name="OnPlayerText"/>
+/// <remarks>Avoid using format specifiers in your messages without formatting the string that is sent. It will result in crashes otherwise.</remarks>
 native SendPlayerMessageToAll(senderid, const message[]);
+
+/// <summary>Adds a death to the 'killfeed' on the right-hand side of the screen for all players.</summary>
+/// <param name="killer">The ID of the killer (can be <b><c>INVALID_PLAYER_ID</c></b>)</param>
+/// <param name="killee">The ID of the player that died</param>
+/// <param name="weapon">The <a href="http://wiki.sa-mp.com/wiki/Weapons">reason</a> (not always a weapon) for the victim's death. Special icons can also be used (<b><c>ICON_CONNECT</c></b> and <b><c>ICON_DISCONNECT</c></b>)</param>
+/// <seealso name="SendDeathMessageToPlayer"/>
+/// <seealso name="OnPlayerDeath"/>
+/// <remarks>Death messages can be cleared by using a valid player ID for <paramref name="killee"/> that is not connected.</remarks>
+/// <remarks>To show a death message for just a single player, use <a href="#SendDeathMessageToPlayer">SendDeathMessageToPlayer</a>. </remarks>
+/// <remarks>You can use NPCs to create your own custom death reasons. </remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even if the function fails to execute. The function fails to execute (no death message shown) if <paramref name="killee"/> is invalid. If <paramref name="reason"/> is invalid, a generic skull-and-crossbones icon is shown. <paramref name="killer"/> being invalid (<b><c>INVALID_PLAYER_ID</c></b>) is valid.</returns>
 native SendDeathMessage(killer, killee, weapon);
+
+/// <summary>Adds a death to the 'killfeed' on the right-hand side of the screen for a single player.</summary>
+/// <param name="playerid">The ID of the player to send the death message to</param>
+/// <param name="killer">The ID of the killer (can be <b><c>INVALID_PLAYER_ID</c></b>)</param>
+/// <param name="killee">The ID of the player that died</param>
+/// <param name="weapon">The <a href="http://wiki.sa-mp.com/wiki/Weapons">reason</a> (not always a weapon) for the victim's death. Special icons can also be used (<b><c>ICON_CONNECT</c></b> and <b><c>ICON_DISCONNECT</c></b>)</param>
+/// <seealso name="SendDeathMessage"/>
+/// <seealso name="OnPlayerDeath"/>
+/// <remarks>This Function was added in <b>SA-MP 0.3z R2-2</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute.
+/// </returns>
 native SendDeathMessageToPlayer(playerid, killer, killee, weapon);
+
+/// <summary>Shows 'game text' (on-screen text) for a certain length of time for all players.</summary>
+/// <param name="string">The text to be displayed</param>
+/// <param name="time">The duration of the text being shown in milliseconds</param>
+/// <param name="style">The style of text to be displayed</param>
+/// <seealso name="GameTextForPlayer"/>
+/// <seealso name="TextDrawShowForAll"/>
+/// <returns>This function always returns <b><c>1</c></b>.</returns>
 native GameTextForAll(const string[],time,style);
+
+/// <summary>Shows 'game text' (on-screen text) for a certain length of time for a specific player.</summary>
+/// <param name="playerid">The ID of the player to show the gametext for</param>
+/// <param name="string">The text to be displayed</param>
+/// <param name="time">The duration of the text being shown in milliseconds</param>
+/// <param name="style">The style of text to be displayed</param>
+/// <seealso name="GameTextForAll"/>
+/// <seealso name="TextDrawShowForPlayer"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. Success is reported when the style and/or time is invalid. Nothing will happen though (no text displayed). May also cause game crashes.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means either the string is null or the player is not connected.
+/// </returns>
 native GameTextForPlayer(playerid,const string[],time,style);
+
+/// <summary>Sets a 'timer' to call a function after some time. Can be set to repeat.</summary>
+/// <param name="funcname">Name of the function to call as a string. This must be a public function (forwarded). A null string here will crash the server</param>
+/// <param name="interval">Interval in milliseconds</param>
+/// <param name="repeating">Whether the timer should repeat or not</param>
+/// <seealso name="SetTimerEx"/>
+/// <seealso name="KillTimer"/>
+/// <remarks>Timer intervals are not accurate (roughly 25% off). There's a fix available <a href="http://forum.sa-mp.com/showthread.php?t=289675">here</a>. </remarks>
+/// <remarks>Timer IDs are never used twice. You can use <a href="#KillTimer">KillTimer</a> on a timer ID and it won't matter if it's running or not. </remarks>
+/// <remarks>The function that should be called must be public. </remarks>
+/// <remarks>The use of many timers will result in increased memory/cpu usage. </remarks>
+/// <returns>The ID of the timer that was started. Timer IDs start at <b><c>1</c></b>.</returns>
 native SetTimer(funcname[], interval, repeating);
+
+/// <summary>Sets a timer to call a function after the specified interval. This variant ('Ex') can pass parameters (such as a player ID) to the function.</summary>
+/// <param name="funcname">The name of a public function to call when the timer expires</param>
+/// <param name="interval">Interval in milliseconds</param>
+/// <param name="repeating">Whether the timer should be called repeatedly (can only be stopped with <a href="#KillTimer">KillTimer</a>) or only once</param>
+/// <param name="format">Special format indicating the types of values the timer will pass</param>
+/// <param name="">Indefinite number of arguments to pass (must follow format specified in previous parameter)</param>
+/// <seealso name="SetTimer"/>
+/// <seealso name="KillTimer"/>
+/// <seealso name="CallLocalFunction"/>
+/// <seealso name="CallRemoteFunction"/>
+/// <remarks>Timer intervals are not accurate (roughly 25% off). There's a fix available <a href="http://forum.sa-mp.com/showthread.php?t=289675">here</a>. </remarks>
+/// <remarks>Timer IDs are never used twice. You can use KillTimer() on a timer ID and it won't matter if it's running or not. </remarks>
+/// <remarks>The function that should be called must be public. </remarks>
+/// <remarks>The use of many timers will result in increased memory/cpu usage. </remarks>
+/// <remarks>
+///   <b>Format syntax:</b><p/>
+///   <ul>
+///     <li><b><c>i</c></b> - integer</li>
+///     <li><b><c>d</c></b> - integer</li>
+///     <li><b><c>a</c></b> - array The next parameter must be an integer (<b><c>"i"</c></b>) with the array's size <b>[CURRENTLY UNUSABLE]</b></li>
+///     <li><b><c>s</c></b> - string <b>[CURRENTLY UNUSABLE]</b></li>
+///     <li><b><c>f</c></b> - float</li>
+///     <li><b><c>b</c></b> - boolean</li>
+///   </ul>
+/// </remarks>
+/// <returns>The ID of the timer that was started. Timer IDs start at <b><c>1</c></b> and are never reused. There are no internal checks to verify that the parameters passed are valid (e.g. duration not a minus value).</returns>
 native SetTimerEx(funcname[], interval, repeating, const format[], {Float,_}:...);
+
+/// <summary>Kills (stops) a running timer.</summary>
+/// <param name="timerid">The ID of the timer to kill (returned by <a href="#SetTimer">SetTimer</a> or <a href="#SetTimerEx">SetTimerEx</a>)</param>
+/// <seealso name="SetTimer"/>
+/// <seealso name="SetTimerEx"/>
+/// <returns>This function always returns <b><c>0</c></b>.</returns>
 native KillTimer(timerid);
+
+/// <summary>Returns the uptime of the actual server (not the SA-MP server) in milliseconds.</summary>
+/// <seealso name="tickcount"/>
+/// <remarks>GetTickCount will cause problems on servers with uptime of over 24 days as GetTickCount will eventually warp past the integer size constraints. However using <a href="https://gist.github.com/ziggi/5d7d8dc42f54531feba7ae924c608e73">this</a> function fixes the problem.</remarks>
+/// <remarks>One common use for GetTickCount is for benchmarking. It can be used to calculate how much time some code takes to execute.</remarks>
+/// <returns>Uptime of the actual server (not the SA-MP server).</returns>
 native GetTickCount();
+
+/// <summary>Returns the maximum number of players that can join the server, as set by the server variable 'maxplayers' in server.cfg.</summary>
+/// <seealso name="GetPlayerPoolSize"/>
+/// <seealso name="IsPlayerConnected"/>
+/// <remarks>This function can not be used in place of <b><c>MAX_PLAYERS</c></b>. It can not be used at compile time (e.g. for array sizes). <b><c>MAX_PLAYERS</c></b> should always be re-defined to what the 'maxplayers' var will be, or higher.</remarks>
+/// <returns>The maximum number of players that can join the server.</returns>
 native GetMaxPlayers();
+
+/// <summary>Calls a public function in any script that is loaded.</summary>
+/// <param name="function">Public function's name</param>
+/// <param name="format">Tag/format of each variable</param>
+/// <param name="">'Indefinite' number of arguments of any tag</param>
+/// <seealso name="CallLocalFunction"/>
+/// <returns>The value that the last public function returned.</returns>
+/// <remarks>CallRemoteFunction crashes the server if it's passing an empty string.</remarks>
+/// <remarks>
+///   Format string placeholders:<p/>
+///   <ul>
+///     <li><b><c>c</c></b> - a single character</li>
+///     <li><b><c>d</c></b> - an integer (whole) number</li>
+///     <li><b><c>i</c></b> - an integer (whole) number</li>
+///     <li><b><c>x</c></b> - a number in hexadecimal notation</li>
+///     <li><b><c>f</c></b> - a floating point number</li>
+///     <li><b><c>s</c></b> - a string</li>
+///   </ul>
+/// </remarks>
 native CallRemoteFunction(const function[], const format[], {Float,_}:...);
+
+/// <summary>Calls a public function from the script in which it is used.</summary>
+/// <param name="function">Public function's name</param>
+/// <param name="format">Tag/format of each variable</param>
+/// <param name="">'Indefinite' number of arguments of any tag</param>
+/// <seealso name="CallRemoteFunction"/>
+/// <returns>The value that the <b>only</b> public function returned.</returns>
+/// <remarks>CallLocalFunction crashes the server if it's passing an empty string.</remarks>
+/// <remarks>
+///   Format string placeholders:<p/>
+///   <ul>
+///     <li><b><c>c</c></b> - a single character</li>
+///     <li><b><c>d</c></b> - an integer (whole) number</li>
+///     <li><b><c>i</c></b> - an integer (whole) number</li>
+///     <li><b><c>x</c></b> - a number in hexadecimal notation</li>
+///     <li><b><c>f</c></b> - a floating point number</li>
+///     <li><b><c>s</c></b> - a string</li>
+///   </ul>
+/// </remarks>
 native CallLocalFunction(const function[], const format[], {Float,_}:...);
+
+
+/// <summary>Returns the norm (length) of the provided vector.</summary>
+/// <param name="x">The vector's magnitude on the X axis</param>
+/// <param name="y">The vector's magnitude on the Y axis</param>
+/// <param name="z">The vector's magnitude on the Z axis</param>
+/// <seealso name="GetPlayerDistanceFromPoint"/>
+/// <seealso name="GetVehicleDistanceFromPoint"/>
+/// <seealso name="floatsqroot"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <returns>The norm (length) of the provided vector as a float.</returns>
 native Float:VectorSize(Float:x, Float:y, Float:z);
+
+/// <summary>Get the inversed value of a sine in radians.</summary>
+/// <param name="value">The sine for which to find the angle for</param>
+/// <seealso name="floatsin"/>
+/// <returns>The angle in radians.</returns>
 native Float:asin(Float:value);
+
+/// <summary>Get the inversed value of a cosine in radians.</summary>
+/// <param name="value">The cosine for which to find the angle for</param>
+/// <seealso name="floatcos"/>
+/// <returns>The angle in radians.</returns>
 native Float:acos(Float:value);
+
+/// <summary>Get the inversed value of a tangent in radians.</summary>
+/// <param name="value">The tangent for which to find the angle for</param>
+/// <seealso name="atan2"/>
+/// <seealso name="floattan"/>
+/// <returns>The angle in radians.</returns>
 native Float:atan(Float:value);
+
+/// <summary>Get the multi-valued inversed value of a tangent in radians.</summary>
+/// <param name="x">x size</param>
+/// <param name="y">y size</param>
+/// <seealso name="atan"/>
+/// <seealso name="floattan"/>
+/// <returns>The angle in radians.</returns>
 native Float:atan2(Float:x, Float:y);
+
+
+/// <summary>Gets the highest playerid currently in use on the server.</summary>
+/// <seealso name="GetVehiclePoolSize"/>
+/// <seealso name="GetMaxPlayers"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>The highest playerid currently in use on the server or <b><c>0</c></b> if there are no connected players.</returns>
 native GetPlayerPoolSize();
+
+/// <summary>Gets the highest vehicleid currently in use on the server.</summary>
+/// <seealso name="GetPlayerPoolSize"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <returns>The highest vehicleid currently in use on the server or <b><c>0</c></b> if there are no created vehicles.</returns>
 native GetVehiclePoolSize();
+
+/// <summary>Gets the highest actorid created on the server.</summary>
+/// <seealso name="CreateActor"/>
+/// <seealso name="IsValidActor"/>
+/// <seealso name="SetActorHealth"/>
+/// <remarks>This function was added in <b><b>SA-MP 0.3.7</b></b> and will not work in earlier versions!</remarks>
+/// <returns>The highest actorid created on the server or <b><c>0</c></b> if there are no created actors.</returns>
 native GetActorPoolSize();
 
 // Hash
+
+/// <summary>Hashes a password using the SHA-256 hashing algorithm. Includes a salt. The output is always 256 bytes in length, or the equivalent of 64 Pawn cells.</summary>
+/// <param name="password">The password to hash</param>
+/// <param name="salt">The salt to use in the hash</param>
+/// <param name="ret_hash">The returned hash</param>
+/// <param name="ret_hash_len">The returned hash maximum length</param>
+/// <remarks>This function was added in <b>SA-MP 0.3.7-R1</b> and will not work in earlier versions!</remarks>
+/// <remarks>The salt is appended to the end of the password, meaning password 'foo' and salt 'bar' would form 'foobar'. </remarks>
+/// <remarks>The salt should be random, unique for each player and at least as long as the hashed password. It is to be stored alongside the actual hash in the player's account. </remarks>
 native SHA256_PassHash(password[], salt[], ret_hash[], ret_hash_len); // SHA256 for password hashing
 
 // Server wide persistent variable system (SVars)
+
+/// <summary>Set an integer server variable.</summary>
+/// <param name="varname">The name of the server variable</param>
+/// <param name="int_value">The integer to be set</param>
+/// <seealso name="GetSVarInt"/>
+/// <seealso name="SetSVarString"/>
+/// <seealso name="GetSVarString"/>
+/// <seealso name="SetSVarFloat"/>
+/// <seealso name="GetSVarFloat"/>
+/// <seealso name="DeleteSVar"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7 R2</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The variable name is null or over 40 characters.
+/// </returns>
 native SetSVarInt(varname[], int_value);
+
+/// <summary>Gets an integer server variable's value.</summary>
+/// <param name="varname">The name of the server variable (case-insensitive). Assigned in SetSVarInt</param>
+/// <seealso name="SetSVarInt"/>
+/// <seealso name="SetSVarString"/>
+/// <seealso name="GetSVarString"/>
+/// <seealso name="SetSVarFloat"/>
+/// <seealso name="GetSVarFloat"/>
+/// <seealso name="DeleteSVar"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7 R2</b> and will not work in earlier versions!</remarks>
+/// <returns>The integer value of the specified server variable. It will still return <b><c>0</c></b> if the variable is not set.</returns>
 native GetSVarInt(varname[]);
+
+/// <summary>Set a string server variable.</summary>
+/// <param name="varname">The name of the server variable</param>
+/// <param name="string_value">The string to be set</param>
+/// <seealso name="SetSVarInt"/>
+/// <seealso name="GetSVarInt"/>
+/// <seealso name="GetSVarString"/>
+/// <seealso name="SetSVarFloat"/>
+/// <seealso name="GetSVarFloat"/>
+/// <seealso name="DeleteSVar"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7 R2</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The variable name is null or over 40 characters.
+/// </returns>
 native SetSVarString(varname[], string_value[]);
+
+/// <summary>Gets a string server variable's value.</summary>
+/// <param name="varname">The name of the server variable (case-insensitive). Assigned in <a href="#SetSVarString">SetSVarString</a></param>
+/// <param name="string_return">The array in which to store the string value in, passed by reference</param>
+/// <param name="len">The maximum length of the returned string</param>
+/// <seealso name="SetSVarInt"/>
+/// <seealso name="GetSVarInt"/>
+/// <seealso name="SetSVarString"/>
+/// <seealso name="SetSVarFloat"/>
+/// <seealso name="GetSVarFloat"/>
+/// <seealso name="DeleteSVar"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7 R2</b> and will not work in earlier versions!</remarks>
+/// <returns>The length of the string.</returns>
 native GetSVarString(varname[], string_return[], len);
+
+/// <summary>Set a float server variable.</summary>
+/// <param name="varname">The name of the server variable</param>
+/// <param name="float_value">The float to be set</param>
+/// <seealso name="SetSVarInt"/>
+/// <seealso name="GetSVarInt"/>
+/// <seealso name="SetSVarString"/>
+/// <seealso name="GetSVarString"/>
+/// <seealso name="GetSVarFloat"/>
+/// <seealso name="DeleteSVar"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7 R2</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The variable name is null or over 40 characters.
+/// </returns>
 native SetSVarFloat(varname[], Float:float_value);
+
+/// <summary>Gets a float server variable's value.</summary>
+/// <param name="varname">The name of the server variable (case-insensitive). Assigned in <a href="#SetSVarFloat">SetSVarFloat</a></param>
+/// <seealso name="SetSVarInt"/>
+/// <seealso name="GetSVarInt"/>
+/// <seealso name="SetSVarString"/>
+/// <seealso name="GetSVarString"/>
+/// <seealso name="SetSVarFloat"/>
+/// <seealso name="DeleteSVar"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7 R2</b> and will not work in earlier versions!</remarks>
+/// <returns>The float value of the specified server variable. It will still return <b><c>0</c></b> if the variable is not set.</returns>
 native Float:GetSVarFloat(varname[]);
+
+/// <summary>Deletes a previously set server variable.</summary>
+/// <param name="varname">The name of the server variable to delete</param>
+/// <seealso name="SetSVarInt"/>
+/// <seealso name="GetSVarInt"/>
+/// <seealso name="SetSVarString"/>
+/// <seealso name="GetSVarString"/>
+/// <seealso name="SetSVarFloat"/>
+/// <seealso name="GetSVarFloat"/>
+/// <remarks>Once a variable is deleted, attempts to retrieve the value will return <b><c>0</c></b> (for integers and floats and <b><c>NULL</c></b> for strings.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. There is no variable set with the given name.
+/// </returns>
 native DeleteSVar(varname[]);
 
 // SVar enumeration
@@ -99,43 +488,402 @@ native DeleteSVar(varname[]);
 #define SERVER_VARTYPE_STRING		2
 #define SERVER_VARTYPE_FLOAT		3
 
+
+/// <summary>Each SVar (server-variable) has its own unique identification number for lookup, this function returns the highest ID.</summary>
+/// <seealso name="GetSVarNameAtIndex"/>
+/// <seealso name="GetSVarType"/>
+/// <returns>The highest set SVar ID.</returns>
 native GetSVarsUpperIndex();
+
+/// <summary>Retrieve the name of a sVar via the index.</summary>
+/// <param name="index">The index of the sVar</param>
+/// <param name="ret_varname">A string to store the sVar's name in, passed by reference</param>
+/// <param name="ret_len">The max length of the returned string, use sizeof()</param>
+/// <seealso name="GetSVarType"/>
+/// <seealso name="GetSVarInt"/>
+/// <seealso name="GetSVarFloat"/>
+/// <seealso name="GetSVarString"/>
 native GetSVarNameAtIndex(index, ret_varname[], ret_len);
+
+/// <summary>Gets the type (integer, float or string) of a server variable.</summary>
+/// <param name="varname">The name of the server variable to get the type of</param>
+/// <seealso name="SetSVarInt"/>
+/// <seealso name="GetSVarInt"/>
+/// <seealso name="SetSVarString"/>
+/// <seealso name="GetSVarString"/>
+/// <seealso name="SetSVarFloat"/>
+/// <seealso name="GetSVarFloat"/>
+/// <seealso name="DeleteSVar"/>
+/// <remarks>
+///   <b>Variable types:</b><p/>
+///   <ul>
+///     <li><b><c>SERVER_VARTYPE_NONE</c></b> (sVar with name given does not exist)</li>
+///     <li><b><c>SERVER_VARTYPE_INT</c></b></li>
+///     <li><b><c>SERVER_VARTYPE_STRING</c></b></li>
+///     <li><b><c>SERVER_VARTYPE_FLOAT</c></b></li>
+///   </ul>
+/// </remarks>
+/// <returns>Returns the type of the SVar. See table below.</returns>
 native GetSVarType(varname[]);
 
 // Game
+
+/// <summary>Set the name of the game mode, which appears in the server browser.</summary>
+/// <param name="string">The gamemode name to display</param>
 native SetGameModeText(const string[]);
+
+
+/// <summary>This function is used to change the amount of teams used in the gamemode. It has no obvious way of being used, but can help to indicate the number of teams used for better (more effective) internal handling. This function should only be used in the <a href="#OnGameModeInit">OnGameModeInit</a> callback. Important: You can pass 2 billion here if you like, this function has no effect at all.</summary>
+/// <param name="count">Number of teams the gamemode knows</param>
+/// <seealso name="GetPlayerTeam"/>
+/// <seealso name="SetPlayerTeam"/>
 native SetTeamCount(count);
+
+/// <summary>Adds a class to class selection. Classes are used so players may spawn with a skin of their choice.</summary>
+/// <param name="modelid">The <a href="http://wiki.sa-mp.com/wiki/Skins">skin</a> which the player will spawn with</param>
+/// <param name="spawn_x">The X coordinate of the spawnpoint of this class</param>
+/// <param name="spawn_y">The Y coordinate of the spawnpoint of this class</param>
+/// <param name="spawn_z">The Z coordinate of the spawnpoint of this class</param>
+/// <param name="z_angle">The direction in which the player should face after spawning</param>
+/// <param name="weapon1">The first spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon1_ammo">The amount of ammunition for the primary spawn weapon</param>
+/// <param name="weapon2">The second spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon2_ammo">The amount of ammunition for the second spawn weapon</param>
+/// <param name="weapon3">The third spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon3_ammo">The amount of ammunition for the third spawn weapon</param>
+/// <returns>
+///   <ul>
+///     <li>The <b>ID of the class</b> which was just added.</li>
+///     <li><b><c>319</c></b> if the class limit (<b><c>320</c></b>) was reached. The highest possible class ID is <b><c>319</c></b>.</li>
+///   </ul>
+/// </returns>
+/// <remarks>
+///    The maximum class ID is <b><c>319</c></b> (starting from <b><c>0</c></b>, so a total of <b><c>320</c></b> classes).
+///    When this limit is reached, any more classes that are added will replace ID <b><c>319</c></b>.
+/// </remarks>
+/// <seealso name="AddPlayerClassEx"/>
+/// <seealso name="SetSpawnInfo"/>
+/// <seealso name="SetPlayerSkin"/>
 native AddPlayerClass(modelid, Float:spawn_x, Float:spawn_y, Float:spawn_z, Float:z_angle, weapon1, weapon1_ammo, weapon2, weapon2_ammo, weapon3, weapon3_ammo);
+
+/// <summary>This function is exactly the same as the <a href="#AddPlayerClass">AddPlayerClass</a> function, with the addition of a team parameter.</summary>
+/// <param name="teamid">The team you want the player to spawn in</param>
+/// <param name="modelid">The <a href="http://wiki.sa-mp.com/wiki/Skins">skin</a> which the player will spawn with</param>
+/// <param name="spawn_x">The X coordinate of the class' spawn position</param>
+/// <param name="spawn_y">The Y coordinate of the class' spawn position</param>
+/// <param name="spawn_z">The Z coordinate of the class' spawn position</param>
+/// <param name="z_angle">The direction in which the player will face after spawning</param>
+/// <param name="weapon1">The first spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon1_ammo">The amount of ammunition for the first spawn weapon</param>
+/// <param name="weapon2">The second spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon2_ammo">The amount of ammunition for the second spawn weapon</param>
+/// <param name="weapon3">The third spawn-<a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> for the player</param>
+/// <param name="weapon3_ammo">The amount of ammunition for the third spawn weapon</param>
+/// <returns>
+///   <ul>
+///     <li>The <b>ID of the class</b> which was just added.</li>
+///     <li><b><c>319</c></b> if the class limit (<b><c>320</c></b>) was reached. The highest possible class ID is <b><c>319</c></b>.</li>
+///   </ul>
+/// </returns>
+/// <remarks>The maximum class ID is <b><c>319</c></b> (starting from <b><c>0</c></b>, so a total of <b><c>320</c></b> classes). When this limit is reached, any more classes that are added will replace ID <b><c>319</c></b>.</remarks>
+/// <seealso name="AddPlayerClass"/>
+/// <seealso name="SetSpawnInfo"/>
+/// <seealso name="SetPlayerTeam"/>
+/// <seealso name="SetPlayerSkin"/>
 native AddPlayerClassEx(teamid, modelid, Float:spawn_x, Float:spawn_y, Float:spawn_z, Float:z_angle, weapon1, weapon1_ammo, weapon2, weapon2_ammo, weapon3, weapon3_ammo);
+
+/// <summary>Adds a 'static' vehicle (models are pre-loaded for players) to the gamemode.</summary>
+/// <param name="modelid">The <a href="http://wiki.sa-mp.com/wiki/Vehicle_Models">Model ID</a> for the vehicle</param>
+/// <param name="spawn_x">The X-coordinate for the vehicle</param>
+/// <param name="spawn_y">The Y-coordinate for the vehicle</param>
+/// <param name="spawn_z">The Z-coordinate for the vehicle</param>
+/// <param name="z_angle">Direction of vehicle - angle</param>
+/// <param name="color1">The primary <a href="http://wiki.sa-mp.com/wiki/Color_ID">color ID</a>. <b><c>-1</c></b> for random (random color chosen by client)</param>
+/// <param name="color2">The secondary <a href="http://wiki.sa-mp.com/wiki/Color_ID">color ID</a>. <b><c>-1</c></b> for random (random color chosen by client)</param>
+/// <returns>
+///   <ul>
+///     <li>The vehicle ID of the vehicle created (between <b><c>1</c></b> and <b><c>MAX_VEHICLES</c></b>).</li>
+///     <li><b><c>INVALID_VEHICLE_ID</c></b> (<b><c>65535</c></b>) if vehicle was not created (vehicle limit reached or invalid vehicle model ID passed).</li>
+///   </ul>
+/// </returns>
+/// <remarks>Can only be used when the server first starts (under <a href="#OnGameModeInit">OnGameModeInit</a>).</remarks>
+/// <seealso name="AddStaticVehicleEx"/>
+/// <seealso name="CreateVehicle"/>
+/// <seealso name="DestroyVehicle"/>
 native AddStaticVehicle(modelid, Float:spawn_x, Float:spawn_y, Float:spawn_z, Float:z_angle, color1, color2);
+
+/// <summary>Adds a 'static' vehicle (models are pre-loaded for players)to the gamemode. Differs from <a href="#AddStaticVehicle">AddStaticVehicle</a> in only one way: allows a respawn time to be set for when the vehicle is left unoccupied by the driver.</summary>
+/// <param name="modelid">The <a href="http://wiki.sa-mp.com/wiki/Vehicle_Models">Model ID</a> for the vehicle</param>
+/// <param name="spawn_x">The X-coordinate for the vehicle</param>
+/// <param name="spawn_y">The Y-coordinate for the vehicle</param>
+/// <param name="spawn_z">The Z-coordinate for the vehicle</param>
+/// <param name="z_angle">The facing - angle for the vehicle</param>
+/// <param name="color1">The primary <a href="http://wiki.sa-mp.com/wiki/Color_ID">color ID</a>. <b><c>-1</c></b> for random (random color chosen by client)</param>
+/// <param name="color2">The secondary <a href="http://wiki.sa-mp.com/wiki/Color_ID">color ID</a>. <b><c>-1</c></b> for random (random color chosen by client)</param>
+/// <param name="respawn_delay">The delay until the car is respawned without a driver, in seconds</param>
+/// <param name="addsiren"><b>Added in 0.3.7; will not work in earlier versions.</b> Enables the vehicle to have a siren, providing the vehicle has a horn (optional=<b><c>0</c></b>)</param>
+/// <returns>
+///   <ul>
+///     <li>The vehicle ID of the vehicle created (between <b><c>1</c></b> and <b><c>MAX_VEHICLES</c></b>).</li>
+///     <li><b><c>INVALID_VEHICLE_ID</c></b> (<b><c>65535</c></b>) if vehicle was not created (vehicle limit reached or invalid vehicle model ID passed).</li>
+///   </ul>
+/// </returns>
+/// <remarks>Can only be used when the server first starts (under <a href="#OnGameModeInit">OnGameModeInit</a>).</remarks>
+/// <seealso name="AddStaticVehicle"/>
+/// <seealso name="CreateVehicle"/>
+/// <seealso name="DestroyVehicle"/>
 native AddStaticVehicleEx(modelid, Float:spawn_x, Float:spawn_y, Float:spawn_z, Float:z_angle, color1, color2, respawn_delay, addsiren=0);
+
+/// <summary>This function adds a 'static' pickup to the game. These pickups support weapons, health, armor etc., with the ability to function without scripting them (weapons/health/armor will be given automatically).</summary>
+/// <param name="model">The model of the pickup</param>
+/// <param name="type">The pickup type. Determines how the pickup responds when picked up</param>
+/// <param name="X">The X coordinate to create the pickup at</param>
+/// <param name="Y">The Y coordinate to create the pickup at</param>
+/// <param name="Z">The Z coordinate to create the pickup at</param>
+/// <param name="virtualworld">The virtual world ID to put the pickup in. Use -1 to show the pickup in all worlds</param>
+/// <returns>
+///   <b><c>1</c></b> if the pickup is successfully created.
+///   <p/>
+///   <b><c>0</c></b> if failed to create.
+/// </returns>
+/// <remarks>This function doesn't return a pickup ID that you can use in, for example, <a href="#OnPlayerPickUpPickup">OnPlayerPickUpPickup</a>. Use <a href="#CreatePickup">CreatePickup</a> if you'd like to assign IDs.</remarks>
+/// <seealso name="CreatePickup"/>
+/// <seealso name="DestroyPickup"/>
+/// <seealso name="OnPlayerPickUpPickup"/>
 native AddStaticPickup(model, type, Float:X, Float:Y, Float:Z, virtualworld = 0);
+
+/// <summary>This function does exactly the same as AddStaticPickup, except it returns a pickup ID which can be used to destroy it afterwards and be tracked using <a href="#OnPlayerPickUpPickup">OnPlayerPickUpPickup</a>.</summary>
+/// <param name="model">The <a href="http://wiki.sa-mp.com/wiki/Pickup_IDs">model</a> of the pickup</param>
+/// <param name="type">The pickup spawn type (see table under remarks)</param>
+/// <param name="X">The X coordinate to create the pickup at</param>
+/// <param name="Y">The Y coordinate to create the pickup at</param>
+/// <param name="Z">The Z coordinate to create the pickup at</param>
+/// <param name="virtualworld">The virtual world ID of the pickup. Use <b><c>-1</c></b> to make the pickup show in all worlds (optional=<b><c>0</c></b>)</param>
+/// <seealso name="AddStaticPickup"/>
+/// <seealso name="DestroyPickup"/>
+/// <seealso name="OnPlayerPickUpPickup"/>
+/// <remarks>
+///   <b>Known Bugs:</b><p/>
+///   Pickups that have a X or Y lower than <b><c>-4096.0</c></b> or bigger than <b><c>4096.0</c></b> won't show up and won't trigger <a href="#OnPlayerPickUpPickup">OnPlayerPickUpPickup</a> either.
+/// </remarks>
+/// <remarks>
+///   The only type of pickup that can be picked up from inside a vehicle is <b><c>14</c></b> (except for special pickups such as bribes).<p/>
+///   Pickups are shown to, and can be picked up by all players.<p/>
+///   It is possible that if <a href="#DestroyPickup">DestroyPickup</a> is used when a pickup is picked up, more than one player can pick up the pickup, due to lag. This can be circumvented through the use of variables.<p/>
+///   Certain pickup types come with 'automatic responses', for example using an M4 model in the pickup will automatically give the player the weapon and some ammo. For fully scripted pickups, type <b><c>1</c></b> should be used. <p/>
+/// </remarks>
+/// <remarks>
+///   <b>Available Pickup Types</b><p/>
+///   Most other IDs are either undocumented or are similar to type <b><c>1</c></b> (but do not use them just because they seem similar to ID <b><c>1</c></b>, they might have side-effects like ID <b><c>18</c></b> and <b><c>20</c></b>).
+///   <ul>
+///     <li><b><c>0</c></b> - The pickup does not always display. If displayed, it can't be picked up and does not trigger <a href="#OnPlayerPickUpPickup">OnPlayerPickUpPickup</a> and it will stay after server shutdown.</li>
+///     <li><b><c>1</c></b> - Exists always. Disables pickup scripts such as horseshoes and oysters to allow for scripted actions ONLY. Will trigger <a href="#OnPlayerPickUpPickup">OnPlayerPickUpPickup</a> every few seconds.</li>
+///     <li><b><c>2</c></b> - Disappears after pickup, respawns after 30 seconds if the player is at a distance of at least 15 meters.</li>
+///     <li><b><c>3</c></b> - Disappears after pickup, respawns after death.</li>
+///     <li><b><c>4</c></b> - Disappears after 15 to 20 seconds. Respawns after death.</li>
+///     <li><b><c>8</c></b> - Disappears after pickup, but has no effect.</li>
+///     <li><b><c>11</c></b> - Blows up a few seconds after being created (bombs?)</li>
+///     <li><b><c>12</c></b> - Blows up a few seconds after being created.</li>
+///     <li><b><c>13</c></b> - Invisible. Triggers checkpoint sound when picked up with a vehicle, but doesn't trigger <a href="#OnPlayerPickUpPickup">OnPlayerPickUpPickup</a>.</li>
+///     <li><b><c>14</c></b> - Disappears after pickup, can only be picked up with a vehicle. Triggers checkpoint sound.</li>
+///     <li><b><c>15</c></b> - Same as type <b><c>2</c></b>.</li>
+///     <li><b><c>18</c></b> - Similar to type <b><c>1</c></b>. Pressing Tab (<b><c>KEY_ACTION</c></b>) makes it disappear but the key press doesn't trigger <a href="#OnPlayerPickUpPickup">OnPlayerPickUpPickup</a>.</li>
+///     <li><b><c>19</c></b> - Disappears after pickup, but doesn't respawn. Makes "cash pickup" sound if picked up.</li>
+///     <li><b><c>20</c></b> - Similar to type <b><c>1</c></b>. Disappears when you take a picture of it with the Camera weapon, which triggers "Snapshot # out of 0" message. Taking a picture doesn't trigger <a href="#OnPlayerPickUpPickup">OnPlayerPickUpPickup</a>.</li>
+///     <li><b><c>22</c></b> - Same as type <b><c>3</c></b>.</li>
+///   </ul>
+/// </remarks>
+/// <returns>The ID of the created pickup, <b><c>-1</c></b> on failure (<a href="http://wiki.sa-mp.com/wiki/Limits">pickup max limit</a>).</returns>
 native CreatePickup(model, type, Float:X, Float:Y, Float:Z, virtualworld = 0);
+
+/// <summary>Destroys a pickup created with <a href="#CreatePickup">CreatePickup</a>.</summary>
+/// <param name="pickup">The ID of the pickup to destroy (returned by <a href="#CreatePickup">CreatePickup</a>)</param>
+/// <seealso name="CreatePickup"/>
+/// <seealso name="OnPlayerPickUpPickup"/>
 native DestroyPickup(pickup);
+
+/// <summary>Toggle the drawing of nametags, health bars and armor bars above players.</summary>
+/// <param name="show"><b><c>0</c></b> to disable, <b><c>1</c></b> to enable (enabled by default)</param>
+/// <seealso name="DisableNameTagLOS"/>
+/// <seealso name="ShowPlayerNameTagForPlayer"/>
+/// <seealso name="ShowPlayerMarkers"/>
+/// <remarks>This function can only be used in <a href="#OnGameModeInit">OnGameModeInit</a>. For other times, see <a href="#ShowPlayerNameTagForPlayer">ShowPlayerNameTagForPlayer</a>.</remarks>
 native ShowNameTags(show);
+
+/// <summary>Toggles player markers (blips on the radar). Must be used when the server starts (<a href="#OnGameModeInit">OnGameModeInit</a>). For other times, see <a href="#SetPlayerMarkerForPlayer">SetPlayerMarkerForPlayer</a>.</summary>
+/// <param name="mode">The mode to use for markers. They can be streamed, meaning they are only visible to nearby players. See table below</param>
+/// <seealso name="SetPlayerMarkerForPlayer"/>
+/// <seealso name="LimitPlayerMarkerRadius"/>
+/// <seealso name="ShowNameTags"/>
+/// <seealso name="SetPlayerColor"/>
+/// <remarks>
+///   <b>Marker modes:</b><p/>
+///   <ul>
+///     <li><b><c>PLAYER_MARKERS_MODE_OFF</c></b> 0</li>
+///     <li><b><c>PLAYER_MARKERS_MODE_GLOBAL</c></b> 1</li>
+///     <li><b><c>PLAYER_MARKERS_MODE_STREAMED</c></b> 2</li>
+///   </ul>
+/// </remarks>
+/// <remarks>It is also possible to set a player's color to a color that has full transparency (no alpha value). This makes it possible to show markers on a per-player basis.</remarks>
 native ShowPlayerMarkers(mode);
+
+/// <summary>Ends the current gamemode.</summary>
+/// <seealso name="OnGameModeExit"/>
 native GameModeExit();
+
+/// <summary>Sets the world time (for all players) to a specific hour.</summary>
+/// <param name="hour">The hour to set (<b><c>0</c></b>-<b><c>23</c></b>)</param>
+/// <seealso name="SetPlayerTime"/>
+/// <seealso name="SetWeather"/>
+/// <seealso name="SetGravity"/>
+/// <remarks>To set the minutes and/or to set the time for individual players, see <a href="#SetPlayerTime">SetPlayerTime</a>.</remarks>
+/// <remarks>This function is only relevant for players that do not use a passing clock - see <a href="#TogglePlayerClock">TogglePlayerClock</a>.</remarks>
 native SetWorldTime(hour);
+
+/// <summary>Get the name of a weapon.</summary>
+/// <param name="weaponid">The ID of the weapon to get the name of</param>
+/// <param name="weapon">An array to store the weapon's name in, passed by reference</param>
+/// <param name="len">The maximum length of the weapon name to store. Should be <c>sizeof(name)</c></param>
+/// <seealso name="GetPlayerWeapon"/>
+/// <seealso name="AllowInteriorWeapons"/>
+/// <seealso name="GivePlayerWeapon"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The weapon specified does not exist.
+/// </returns>
 native GetWeaponName(weaponid, const weapon[], len);
+
+/// <param name="enable"><b><c>1</c></b> to enable, <b><c>0</c></b> to disable tire popping</param>
+/// <remarks>This function was removed in <b>SA-MP 0.3</b>. Tire popping is enabled by default. If you want to disable tire popping, you'll have to manually script it using <a href="#OnVehicleDamageStatusUpdate">OnVehicleDamageStatusUpdate</a>.</remarks>
 native EnableTirePopping(enable); // deprecated function
+
+/// <summary>Enable friendly fire for team vehicles. Players will be unable to damage teammates' vehicles (<a href="#SetPlayerTeam">SetPlayerTeam</a> must be used!).</summary>
+/// <seealso name="SetPlayerTeam"/>
+/// <remarks>This function was added in <b>SA-MP 0.3x</b> and will not work in earlier versions!</remarks>
 native EnableVehicleFriendlyFire();
+
+/// <summary>Toggle whether the usage of weapons in interiors is allowed or not.</summary>
+/// <param name="allow"><b><c>1</c></b> to enable weapons in interiors (enabled by default), <b><c>0</c></b> to disable weapons in interiors</param>
+/// <remarks>This function does not work in the current SA:MP version!</remarks>
+/// <seealso name="SetPlayerInterior"/>
+/// <seealso name="GetPlayerInterior"/>
+/// <seealso name="OnPlayerInteriorChange"/>
 native AllowInteriorWeapons(allow);
+
+
+/// <summary>Set the world weather for all players.</summary>
+/// <param name="weatherid">The <a href="http://wiki.sa-mp.com/wiki/WeatherID">weather</a> to set</param>
+/// <seealso name="SetPlayerWeather"/>
+/// <seealso name="SetGravity"/>
+/// <remarks>If <a href="#TogglePlayerClock">TogglePlayerClock</a> is enabled, weather will slowly change over time, instead of changing instantly.</remarks>
 native SetWeather(weatherid);
+
+/// <summary>Get the currently set gravity.</summary>
+/// <seealso name="SetGravity"/>
+/// <returns>The current set gravity (as a float).</returns>
+native GetGravity();
+
+/// <summary>Set the gravity for all players.</summary>
+/// <param name="gravity">The value that the gravity should be set to (between -50 and 50)</param>
+/// <seealso name="GetGravity"/>
+/// <seealso name="SetWeather"/>
+/// <seealso name="SetWorldTime"/>
+/// <remarks>Default gravity is <b><c>0.008</c></b>.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even when it fails to execute if the gravity is out of the limits (lower than <b><c>-50.0</c></b> or higher than <b><c>+50.0</c></b>).</returns>
 native SetGravity(Float:gravity);
+
+/// <summary>This function will determine whether RCON admins will be teleported to their waypoint when they set one.</summary>
+/// <param name="allow"><b><c>0</c></b> to disable and <b><c>1</c></b> to enable</param>
+/// <remarks><b>This function, as of 0.3d, is deprecated. Please see <a href="#OnPlayerClickMap">OnPlayerClickMap</a>.</b></remarks>
+/// <seealso name="IsPlayerAdmin"/>
+/// <seealso name="AllowPlayerTeleport"/>
 native AllowAdminTeleport(allow);
+
+/// <summary>This function does not work in the current SA:MP version! </summary>
+/// <seealso name="CreatePickup"/>
+/// <seealso name="GivePlayerMoney"/>
+/// <seealso name="OnPlayerDeath"/>
 native SetDeathDropAmount(amount);
+
+/// <summary>Create an explosion at the specified coordinates.</summary>
+/// <param name="X">The X coordinate of the explosion</param>
+/// <param name="Y">The Y coordinate of the explosion</param>
+/// <param name="Z">The Z coordinate of the explosion</param>
+/// <param name="type">The type of explosion</param>
+/// <param name="Radius">The explosion radius</param>
+/// <seealso name="CreateExplosionForPlayer"/>
+/// <remarks>There is a limit as to how many explosions can be seen at once by a player. This is roughly 10.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even when the explosion type and/or radius values are invalid.</returns>
 native CreateExplosion(Float:X, Float:Y, Float:Z, type, Float:Radius);
+
+/// <summary>This function allows to turn on zone / area names such as the "Vinewood" or "Doherty" text at the bottom-right of the screen as they enter the area. This is a gamemode option and should be set in the callback <a href="#OnGameModeInit">OnGameModeInit</a>.</summary>
+/// <param name="enable">A toggle option for whether or not you'd like zone names on or off</param>
+/// <remarks><b>This function was removed in SA-MP 0.3. This was due to crashes it caused.</b></remarks>
 native EnableZoneNames(enable);
+
+/// <summary>Uses standard player walking animation (animation of the CJ skin) instead of custom animations for every skin (e.g. skating for skater skins).</summary>
+/// <seealso name="ApplyAnimation"/>
+/// <seealso name="ClearAnimations"/>
+/// <remarks>Only works when placed under <a href="#OnGameModeInit">OnGameModeInit</a>.</remarks>
+/// <remarks>Not using this function causes two-handed weapons (not dual-handed - a single weapon that is held by both hands) to be held in only one hand.</remarks>
 native UsePlayerPedAnims(); // Will cause the players to use CJ running/walking animations
+
+/// <summary>Disable all the interior entrances and exits in the game (the yellow arrows at doors).</summary>
+/// <seealso name="AllowInteriorWeapons"/>
+/// <remarks>If the gamemode is changed after this function has been used, and the new gamemode doesn't disable markers, the markers will NOT reappear for already-connected players (but will for newly connected players).</remarks>
+/// <remarks>This function will only work if it has been used BEFORE a player connects (it is recommended to use it in OnGameModeInit). It will not remove a connected player's markers.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>.</returns>
 native DisableInteriorEnterExits();  // will disable all interior enter/exits in the game.
+
+/// <summary>Set the maximum distance to display the names of players.</summary>
+/// <param name="distance">The distance to set</param>
+/// <seealso name="LimitGlobalChatRadius"/>
+/// <seealso name="ShowNameTags"/>
+/// <seealso name="ShowPlayerNameTagForPlayer"/>
+/// <remarks>Default distance is <b>70</b> SA units</remarks>
 native SetNameTagDrawDistance(Float:distance); // Distance at which nametags will start rendering on the client.
+
+/// <summary>Disables the nametag Line-Of-Sight checking so that players can see nametags through objects.</summary>
+/// <seealso name="ShowNameTags"/>
+/// <seealso name="ShowPlayerNameTagForPlayer"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This can not be reversed until the server restarts.</remarks>
 native DisableNameTagLOS(); // Disables the nametag Line-Of-Sight checking
+
+/// <summary>Set a radius limitation for the chat. Only players at a certain distance from the player will see their message in the chat. Also changes the distance at which a player can see other players on the map at the same distance.</summary>
+/// <param name="chat_radius">The range in which players will be able to see chat</param>
+/// <seealso name="SetNameTagDrawDistance"/>
+/// <seealso name="SendPlayerMessageToPlayer"/>
+/// <seealso name="SendPlayerMessageToAll"/>
+/// <seealso name="OnPlayerText"/>
 native LimitGlobalChatRadius(Float:chat_radius);
+
+/// <summary>Set the player marker radius.</summary>
+/// <param name="marker_radius">The radius that markers will show at</param>
+/// <seealso name="ShowPlayerMarkers"/>
+/// <seealso name="SetPlayerMarkerForPlayer"/>
+/// <seealso name="LimitGlobalChatRadius"/>
+/// <remarks>This Function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native LimitPlayerMarkerRadius(Float:marker_radius);
 
 // Npc
+
+/// <summary>Connect an NPC to the server.</summary>
+/// <param name="name">The name the NPC should connect as. Must follow the same rules as normal player names</param>
+/// <param name="script">The NPC script name that is located in the <b>npcmodes</b> folder (without the .amx extension)</param>
+/// <seealso name="IsPlayerNPC"/>
+/// <seealso name="OnPlayerConnect"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>NPCs do not have nametags. These can be scripted with <a href="#Attach3DTextLabelToPlayer">Attach3DTextLabelToPlayer</a>.</remarks>
+/// <returns>This function always return <b><c>1</c></b>.</returns>
 native ConnectNPC(name[], script[]);
+
+/// <summary>Check if a player is an actual player or an NPC.</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="ConnectNPC"/>
+/// <seealso name="IsPlayerAdmin"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the player is an NPC, <b><c>0</c></b> if not.</returns>
 native IsPlayerNPC(playerid);
 
 // Artwork/NetModels
@@ -151,99 +899,1020 @@ native FindTextureFileNameFromCRC(crc, retstr[], retstr_size);
 native RedirectDownload(playerid, url[]);
 
 // Admin
+
+/// <summary>Check if a player is logged in as an RCON admin.</summary>
+/// <param name="playerid">The ID of the player to check</param>
+/// <seealso name="SendRconCommand"/>
+/// <seealso name="OnRconLoginAttempt"/>
+/// <returns><b><c>1</c></b> if the player is an RCON admin, <b><c>0</c></b> if not.</returns>
 native IsPlayerAdmin(playerid);
+
+/// <summary>Kicks a player from the server. They will have to quit the game and re-connect if they wish to continue playing.</summary>
+/// <param name="playerid">The ID of the player to kick</param>
+/// <seealso name="Ban"/>
+/// <seealso name="BanEx"/>
+/// <remarks>As of <b>SA-MP 0.3x</b>, any action taken directly before Kick() (such as sending a message with <a href="#SendClientMessage">SendClientMessage</a>) will not reach the player. A timer must be used to delay the kick.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even if the function failed to execute (player specified doesn't exist).</returns>
 native Kick(playerid);
+
+/// <summary>Ban a player who is currently in the server. They will be unable to join the server ever again. The ban will be IP-based, and be saved in the samp.ban file in the server's root directory. <a href="#BanEx">BanEx</a> can be used to give a reason for the ban. IP bans can be added/removed using the RCON banip and unbanip commands (<a href="#SendRconCommand">SendRconCommand</a>).</summary>
+/// <param name="playerid">The ID of the player to ban</param>
+/// <seealso name="BanEx"/>
+/// <seealso name="Kick"/>
+/// <remarks>As of <b>SA-MP 0.3x</b>, any action taken directly before Ban() (such as sending a message with SendClientMessage) will not reach the player. A timer must be used to delay the ban.</remarks>
+/// <remarks></remarks>
 native Ban(playerid);
+
+/// <summary>Ban a player with a reason.</summary>
+/// <param name="playerid">The ID of the player to ban</param>
+/// <param name="reason">The reason for the ban</param>
+/// <seealso name="Ban"/>
+/// <seealso name="Kick"/>
+/// <remarks>As of <b>SA-MP 0.3x</b>, any action taken directly before Ban() (such as sending a message with SendClientMessage) will not reach the player. A timer must be used to delay the ban.</remarks>
 native BanEx(playerid, const reason[]);
+
+
+/// <summary>Sends an RCON (Remote Console) command.</summary>
+/// <param name="command">The RCON command to be executed</param>
+/// <seealso name="IsPlayerAdmin"/>
+/// <seealso name="OnRconCommand"/>
+/// <seealso name="OnRconLoginAttempt"/>
+/// <remarks>Does not support login, due to the lack of a 'playerid' parameter.</remarks>
+/// <remarks>'password 0' will remove the server's password if one is set.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>.</returns>
+/// <remarks>This function will result in <a href="#OnRconCommand">OnRconCommand</a> being called.</remarks>
 native SendRconCommand(command[]);
+
+/// <summary>Gets a player's network stats and saves them into a string.</summary>
+/// <param name="playerid">The ID of the player you want to get the networkstats of</param>
+/// <param name="retstr">The string to store the networkstats in, passed by reference</param>
+/// <param name="retstr_size">The length of the string that should be stored</param>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c R4</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function may not return accurate data when used under <a href="#OnPlayerDisconnect">OnPlayerDisconnect</a> if the player has quit normally. It usually returns accurate data if the player has been kicked or has timed out.</remarks>
 native GetPlayerNetworkStats(playerid, retstr[], retstr_size);
+
+/// <summary>Gets the server's network stats and stores them in a string.</summary>
+/// <param name="retstr">The string to store the network stats in, passed by reference</param>
+/// <param name="retstr_size">The length of the string to be stored</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c R4</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Example output:</b><p/>
+///   <c>
+///     Server Ticks: 200<p/>
+///     Messages in Send buffer: 0<p/>
+///     Messages sent: 142<p/>
+///     Bytes sent: 8203<p/>
+///     Acks sent: 11<p/>
+///     Acks in send buffer: 0<p/>
+///     Messages waiting for ack: 0<p/>
+///     Messages resent: 0<p/>
+///     Bytes resent: 0<p/>
+///     Packetloss: 0.0%<p/>
+///     Messages received: 54<p/>
+///     Bytes received: 2204<p/>
+///     Acks received: 0<p/>
+///     Duplicate acks received: 0<p/>
+///     Inst. KBits per second: 28.8<p/>
+///     KBits per second sent: 10.0<p/>
+///     KBits per second received: 2.7<p/>
+///   </c>
+/// </remarks>
+/// <returns>This function always returns <b><c>1</c></b>.</returns>
 native GetNetworkStats(retstr[], retstr_size);
+
+/// <summary>Returns the SA-MP client version, as reported by the player.</summary>
+/// <param name="playerid">The ID of the player to get the client version of</param>
+/// <param name="version">The string to store the player's version in, passed by reference</param>
+/// <param name="len">The maximum length of the version</param>
+/// <seealso name="GetPlayerName"/>
+/// <seealso name="GetPlayerPing"/>
+/// <seealso name="GetPlayerIp"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>The string the version gets stored in will be empty if playerid is an NPC.</remarks>
+/// <returns><b><c>1</c></b> on success and <b><c>0</c></b> on failure (if player specified doesn't exist).</returns>
 native GetPlayerVersion(playerid, const version[], len); // Returns the SA-MP client revision as reported by the player
+
+/// <summary>Blocks an IP address from further communication with the server for a set amount of time (with wildcards allowed). Players trying to connect to the server with a blocked IP address will receive the generic "You are banned from this server." message. Players that are online on the specified IP before the block will timeout after a few seconds and, upon reconnect, will receive the same message.</summary>
+/// <param name="ip_address">The IP to block</param>
+/// <param name="timems">The time (in milliseconds) that the connection will be blocked for. <b><c>0</c></b> can be used for an indefinite block</param>
+/// <seealso name="UnBlockIpAddress"/>
+/// <seealso name="OnIncomingConnection"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z R2-2</b> and will not work in earlier versions!</remarks>
+/// <remarks>Wildcards can be used with this function, for example blocking the IP <b><c>6.9.*.*</c></b> will block all IPs where the first two octets are <b><c>6</c></b> and <b><c>9</c></b> respectively. Any number can be in place of an asterisk.</remarks>
 native BlockIpAddress(ip_address[], timems);
+
+
+/// <summary>Unblock an IP address that was previously blocked using <a href="#BlockIpAddress">BlockIpAddress</a>.</summary>
+/// <param name="ip_address">The IP address to unblock</param>
+/// <seealso name="BlockIpAddress"/>
+/// <seealso name="OnIncomingConnection"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z R2-2</b> and will not work in earlier versions!</remarks>
 native UnBlockIpAddress(ip_address[]);
 
 // Deprecated:
+
+/// <summary>Get the string value of a server variable.</summary>
+/// <param name="varname">The name of the string variable to get the value of</param>
+/// <param name="buffer">An array into which to store the value, passed by reference</param>
+/// <param name="len">The length of the string that should be stored</param>
+/// <seealso name="GetServerVarAsInt"/>
+/// <seealso name="GetServerVarAsBool"/>
+/// <remarks>This function, as of <b>0.3.7 R2</b>, is deprecated. Please see <a href="#GetConsoleVarAsString">GetConsoleVarAsString</a></remarks>
+/// <remarks>Using this function on anything other than a <b>string</b> (int, bool or float) or a <b>nonexistent</b> server variable, will <b>crash</b> your server! This is a bug.</remarks>
+/// <remarks>Type 'varlist' in the server console to display a list of available server variables and their types.</remarks>
+/// <remarks>When filterscripts or plugins is specified as the varname, this function only returns the name of the first specified filterscript or plugin. This is a bug.</remarks>
+/// <returns>The length of the returned string. <b><c>0</c></b> if the specified server variable is not a string or doesn't exist.</returns>
 native GetServerVarAsString(const varname[], buffer[], len);
+
+/// <summary>Get the integer value of a server variable.</summary>
+/// <param name="varname">The name of the integer variable to get the value of</param>
+/// <seealso name="GetServerVarAsString"/>
+/// <seealso name="GetServerVarAsBool"/>
+/// <remarks>This function, as of <b>0.3.7 R2</b>, is deprecated. Please see <a href="#GetConsoleVarAsInt">GetConsoleVarAsInt</a></remarks>
+/// <remarks>Type 'varlist' in the server console to display a list of available server variables and their types.</remarks>
+/// <returns>The value of the specified server variable. 0 if the specified server variable is not an integer or doesn't exist.</returns>
 native GetServerVarAsInt(const varname[]);
+
+/// <summary>Get the boolean value of a server variable.</summary>
+/// <param name="varname">The name of the boolean variable to get the value of</param>
+/// <seealso name="GetServerVarAsString"/>
+/// <seealso name="GetServerVarAsInt"/>
+/// <remarks>This function, as of <b>0.3.7 R2</b>, is deprecated. Please see <a href="#GetConsoleVarAsBool">GetConsoleVarAsBool</a></remarks>
+/// <remarks>Type 'varlist' in the server console to display a list of available server variables and their types.</remarks>
+/// <returns>The value of the specified server variable. <b><c>0</c></b> if the specified server variable is not a boolean or doesn't exist.</returns>
 native GetServerVarAsBool(const varname[]);
 // These are the same 3 functions as above although they avoid the name ambiguity/conflict with the SVar system.
+
+/// <summary>Get the string value of a console variable.</summary>
+/// <param name="varname">The name of the string variable to get the value of</param>
+/// <param name="buffer">An array into which to store the value, passed by reference</param>
+/// <param name="len">The length of the string that should be stored</param>
+/// <seealso name="GetConsoleVarAsInt"/>
+/// <seealso name="GetConsoleVarAsBool"/>
+/// <remarks>Type <b><c>varlist</c></b> in the server console to display a list of available console variables and their types.</remarks>
+/// <remarks>When filterscripts or plugins are specified as the varname, this function only returns the name of the first specified filterscript or plugin.</remarks>
+/// <remarks>Using this function with anything other than a <b>string</b> (integer, boolean or float) will cause your server to crash. Using it with a nonexistent console variable will also cause your server to crash.</remarks>
+/// <returns>The length of the returned string. <b><c>0</c></b> if the specified console variable is not a string or doesn't exist.</returns>
 native GetConsoleVarAsString(const varname[], buffer[], len);
+
+/// <summary>Get the integer value of a console variable.</summary>
+/// <param name="varname">The name of the integer variable to get the value of</param>
+/// <seealso name="GetConsoleVarAsString"/>
+/// <seealso name="GetConsoleVarAsBool"/>
+/// <remarks>Type <b><c>varlist</c></b> in the server console to display a list of available console variables and their types.</remarks>
+/// <returns>The value of the specified console variable. <b><c>0</c></b> if the specified console variable is not an integer or doesn't exist.</returns>
 native GetConsoleVarAsInt(const varname[]);
+
+/// <summary>Get the boolean value of a console variable.</summary>
+/// <param name="varname">The name of the boolean variable to get the value of</param>
+/// <seealso name="GetConsoleVarAsString"/>
+/// <seealso name="GetConsoleVarAsInt"/>
+/// <remarks>Type <b><c>varlist</c></b> in the server console to display a list of available console variables and their types.</remarks>
+/// <returns>The value of the specified console variable. <b><c>0</c></b> if the specified console variable is not a boolean or doesn't exist.</returns>
 native GetConsoleVarAsBool(const varname[]);
 
 // Extended admin network stats
+
+/// <summary>Gets the tick rate (like FPS) of the server.</summary>
+/// <seealso name="GetNetworkStats"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <returns>The server tick rate (per second). Returns <b><c>0</c></b> when the server is just started.</returns>
 native GetServerTickRate();
+
+/// <summary>Gets the amount of time (in milliseconds) that a player has been connected to the server for.</summary>
+/// <param name="playerid">The ID of the player to get the connected time of</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <remarks>The return value is not reset to zero after changing the game mode (using the RCON command "gmx").</remarks>
+/// <returns>This function returns the amount of time (in milliseconds) that a player has been connected to the server for. <b><c>0</c></b> is returned if the player is not connected.</returns>
 native NetStats_GetConnectedTime(playerid);
+
+/// <summary>Gets the number of messages the server has received from the player.</summary>
+/// <param name="playerid">The ID of the player to get the data from</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <returns>This function returns the number of messages the server has received from the player. <b><c>0</c></b> is returned if the player is not connected.</returns>
 native NetStats_MessagesReceived(playerid);
+
+/// <summary>Gets the amount of data (in bytes) that the server has received from the player.</summary>
+/// <param name="playerid">The ID of the player to get the data from</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <returns>This function returns the number of bytes the server has received from the player. <b><c>0</c></b> is returned if the player is not connected.</returns>
 native NetStats_BytesReceived(playerid);
+
+/// <summary>Gets the number of messages the server has sent to the player.</summary>
+/// <param name="playerid">The ID of the player to get the data from</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <returns>The number of messages the server has sent to the player.</returns>
 native NetStats_MessagesSent(playerid);
+
+/// <summary>Gets the amount of data (in bytes) that the server has sent to the player.</summary>
+/// <param name="playerid">The ID of the player to get the data from</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <returns>This function returns the number of bytes the server has sent to the player. <b><c>0</c></b> is returned if the player is not connected.</returns>
 native NetStats_BytesSent(playerid);
+
+/// <summary>Gets the number of messages the player has received in the last second.</summary>
+/// <param name="playerid">The ID of the player to get the data from</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <returns>the number of messages the player has received in the last second.</returns>
 native NetStats_MessagesRecvPerSecond(playerid);
+
+/// <summary>Gets the packet loss percentage of a player. Packet loss means data the player is sending to the server is being lost (or vice-versa).</summary>
+/// <param name="playerid">The ID of the player to get the data from</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <remarks>Anything greater than 0.0% should already be a cause of concern. Anything greater than 1.0% is outright bad.</remarks>
+/// <remarks>This function has been found to be currently unreliable the output is not as expected when compared to the client. Therefore this function should not be used as a packet loss kicker. </remarks>
+/// <remarks>A more accurate packetloss function can be found here: <a href="http://forum.sa-mp.com/showpost.php?p=2488911&amp;postcount=984">http://forum.sa-mp.com/showpost.php?p=2488911&amp;postcount=984</a></remarks>
+/// <returns>The percentage packet loss as a float. <b><c>0.0</c></b> if player not connected.</returns>
 native Float:NetStats_PacketLossPercent(playerid);
+
+/// <summary>Gets the player's current connection status.</summary>
+/// <param name="playerid">The ID of the player to get the connection status of</param>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_GetIpPort"/>
+/// <seealso name="IsPlayerConnected"/>
+/// <seealso name="OnPlayerConnect"/>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Status:</b><p/>
+///   <ul>
+///     <li><b><c>0 - NO_ACTION</c></b></li>
+///     <li><b><c>1 - DISCONNECT_ASAP</c></b></li>
+///     <li><b><c>2 - DISCONNECT_ASAP_SILENTLY</c></b></li>
+///     <li><b><c>3 - DISCONNECT_ON_NO_ACK</c></b></li>
+///     <li><b><c>4 - REQUESTED_CONNECTION</c></b></li>
+///     <li><b><c>5 - HANDLING_CONNECTION_REQUEST</c></b></li>
+///     <li><b><c>6 - UNVERIFIED_SENDER</c></b></li>
+///     <li><b><c>7 - SET_ENCRYPTION_ON_MULTIPLE_16_BYTE_PACKET</c></b></li>
+///     <li><b><c>8 - CONNECTED</c></b></li>
+///   </ul>
+/// </remarks>
+/// <returns>The player's connection status, as an integer value.</returns>
 native NetStats_ConnectionStatus(playerid);
+
+/// <summary>Get a player's IP and port.</summary>
+/// <param name="playerid">The ID of the player to get the IP and port of</param>
+/// <param name="ip_port">A string array to store the IP and port in, passed by reference</param>
+/// <param name="ip_port_len">The maximum length of the IP/port. 22 is recommended</param>
+/// <seealso name="GetPlayerIp"/>
+/// <seealso name="GetPlayerNetworkStats"/>
+/// <seealso name="GetNetworkStats"/>
+/// <seealso name="NetStats_GetConnectedTime"/>
+/// <seealso name="NetStats_MessagesReceived"/>
+/// <seealso name="NetStats_BytesReceived"/>
+/// <seealso name="NetStats_MessagesSent"/>
+/// <seealso name="NetStats_BytesSent"/>
+/// <seealso name="NetStats_MessagesRecvPerSecond"/>
+/// <seealso name="NetStats_PacketLossPercent"/>
+/// <seealso name="NetStats_ConnectionStatus"/>
+/// <remarks>This function was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
 native NetStats_GetIpPort(playerid, ip_port[], ip_port_len);
 
 // Menu
+
+/// <summary>Creates a menu.</summary>
+/// <param name="title">The title for the new menu</param>
+/// <param name="columns">How many colums shall the new menu have</param>
+/// <param name="x">The X position of the menu (640x460 canvas - <b><c>0</c></b> would put the menu at the far left)</param>
+/// <param name="y">The Y position of the menu (640x460 canvas - <b><c>0</c></b> would put the menu at the far top)</param>
+/// <param name="col1width">The width for the first column</param>
+/// <param name="col2width">The width for the second column (optional=<b><c>0.0</c></b>)</param>
+/// <seealso name="AddMenuItem"/>
+/// <seealso name="SetMenuColumnHeader"/>
+/// <seealso name="DestroyMenu"/>
+/// <seealso name="ShowMenuForPlayer"/>
+/// <seealso name="HideMenuForPlayer"/>
+/// <seealso name="OnPlayerSelectedMenuRow"/>
+/// <seealso name="OnPlayerExitedMenu"/>
+/// <remarks>
+///   This function merely CREATES the menu - <a href="#ShowMenuForPlayer">ShowMenuForPlayer</a> must be used to show it.<p/>
+///   You can only create and access <b><c>2</c></b> columns (<b><c>0</c></b> and <b><c>1</c></b>).<p/>
+///   If the title's length is equal to or greater than <b><c>32</c></b> chars the title is truncated to <b><c>30</c></b> characters.
+/// </remarks>
+/// <remarks>There is a limit of <b><c>12</c></b> items per menu, and a limit of <b><c>128</c></b> menus in total.</remarks>
+/// <returns>The ID of the new menu or <b><c>-1</c></b> on failure.</returns>
 native Menu:CreateMenu(const title[], columns, Float:x, Float:y, Float:col1width, Float:col2width = 0.0);
+
+/// <summary>Destroys the specified menu.</summary>
+/// <param name="menuid">The menu ID to destroy</param>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="SetMenuColumnHeader"/>
+/// <seealso name="AddMenuItem"/>
+/// <seealso name="OnPlayerSelectedMenuRow"/>
+/// <seealso name="OnPlayerExitedMenu"/>
+/// <returns><b><c>1</c></b> if the destroying was successful, otherwise <b><c>0</c></b>.</returns>
 native DestroyMenu(Menu:menuid);
+
+/// <summary>Adds an item to a specified menu.</summary>
+/// <param name="menuid">The menu id to add an item to</param>
+/// <param name="column">The column to add the item to</param>
+/// <param name="menutext">The text for the new menu item</param>
+/// <remarks>
+///   <ul>
+///     <li>Crashes when passed an invalid menu ID.</li>
+///     <li>You can only have <b><c>12</c></b> items per menu (13th goes to the right side of the header of column name (colored), 14th and higher not display at all).</li>
+///     <li>You can only use <b><c>2</c></b> columns (<b><c>0</c></b> and <b><c>1</c></b>).</li>
+///     <li>You can only add <b><c>8</c></b> color codes per one item (<b><c>~r~</c></b>, <b><c>~g~</c></b> etc.).</li>
+///     <li>Maximum length of menu item is <b><c>31</c></b> symbols. </li>
+///   </ul>
+/// </remarks>
+/// <returns>The index of the row this item was added to.</returns>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="SetMenuColumnHeader"/>
+/// <seealso name="DestroyMenu"/>
+/// <seealso name="OnPlayerSelectedMenuRow"/>
+/// <seealso name="OnPlayerExitedMenu"/>
 native AddMenuItem(Menu:menuid, column, const menutext[]);
+
+/// <summary>Sets the caption of a column in a menu.</summary>
+/// <param name="menuid">ID of the menu to change</param>
+/// <param name="column">The column (<b><c>0</c></b> or <b><c>1</c></b>) to set the header of</param>
+/// <param name="columnheader">The caption text for the column</param>
+/// <seealso name="AddMenuItem"/>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="OnPlayerSelectedMenuRow"/>
+/// <remarks>Crashes when passed an invalid menu ID.</remarks>
+/// <remarks>Note that you can add only <b><c>12</c></b> items with <a href="#AddMenuItem">AddMenuItem</a>. The 13th object of a menu would replace the header of the column which is correctly set with this function.</remarks>
 native SetMenuColumnHeader(Menu:menuid, column, const columnheader[]);
+
+/// <summary>Shows a previously created menu for a player.</summary>
+/// <param name="menuid">The ID of the menu to show. Returned by CreateMenu</param>
+/// <param name="playerid">The ID of the player to whom the menu will be shown</param>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="AddMenuItem"/>
+/// <seealso name="SetMenuColumnHeader"/>
+/// <seealso name="ShowPlayerDialog"/>
+/// <seealso name="OnPlayerSelectedMenuRow"/>
+/// <seealso name="OnPlayerExitedMenu"/>
+/// <remarks>Crashes the both server and player if an invalid menu ID given.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. Menu and/or player doesn't exist.
+/// </returns>
 native ShowMenuForPlayer(Menu:menuid, playerid);
+
+/// <summary>Hides a menu for a player.</summary>
+/// <param name="menuid">The ID of the menu to hide. Returned by <a href="#CreateMenu">CreateMenu</a> and passed to <a href="#OnPlayerSelectedMenuRow">OnPlayerSelectedMenuRow</a></param>
+/// <param name="playerid">The ID of the player that the menu will be hidden for</param>
+/// <seealso name="ShowMenuForPlayer"/>
+/// <seealso name="AddMenuItem"/>
+/// <seealso name="SetMenuColumnHeader"/>
+/// <seealso name="CreateMenu"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute.
+/// </returns>
 native HideMenuForPlayer(Menu:menuid, playerid);
+
+/// <summary>Check if a menu ID is vliad.</summary>
+/// <param name="menuid">The menu to check for existance</param>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="DestroyMenu"/>
+/// <returns><b><c>1</c></b> if the menu is valid, otherwise <b><c>0</c></b>.</returns>
 native IsValidMenu(Menu:menuid);
+
+/// <summary>Disable a menu.</summary>
+/// <param name="menuid">The ID of the menu to disable</param>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="DestroyMenu"/>
+/// <seealso name="AddMenuItem"/>
+/// <remarks>Crashes when passed an invalid menu ID.</remarks>
 native DisableMenu(Menu:menuid);
+
+/// <summary>Disable a specific row in a menu <b>for all players</b>. It will be greyed-out and can't be selected by players.</summary>
+/// <param name="menuid">The ID of the menu to disable a row of. Ensure this is valid, as an invalid menu ID will crash the entire server</param>
+/// <param name="row">The ID of the row to disable (rows start at 0)</param>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="DestroyMenu"/>
+/// <seealso name="AddMenuItem"/>
+/// <remarks>
+///   Crashes when passed an invalid menu ID.<p/>
+///   This function disabled the specified menu row for <b>all players</b>. There is no function to disable a menu row for a specific player. You'd have to create two menus - one with a row disabled, and one without. Or one per player.
+/// </remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even if the function fails. If an invalid row is specified, nothing will happen. If an invalid menu ID is specified, the server will crash.</returns>
 native DisableMenuRow(Menu:menuid, row);
+
+/// <summary>Gets the ID of the menu the player is currently viewing (shown by <a href="#ShowMenuForPlayer">ShowMenuForPlayer</a>).</summary>
+/// <param name="playerid">The ID of the player to get the current menu of</param>
+/// <seealso name="ShowMenuForPlayer"/>
+/// <seealso name="HideMenuForPlayer"/>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="DestroyMenu"/>
+/// <seealso name="AddMenuItem"/>
+/// <seealso name="OnPlayerSelectedMenuRow"/>
+/// <seealso name="OnPlayerExitedMenu"/>
+/// <remarks>Returns previous menu when none is displayed.</remarks>
+/// <returns>The ID of the player's currently shown menu, or <b><c>INVALID_MENU</c></b> (<b><c>255</c></b>) if no menu shown.</returns>
 native Menu:GetPlayerMenu(playerid);
 
 // Text Draw
 #define TEXT_DRAW_FONT_SPRITE_DRAW	 4
 #define TEXT_DRAW_FONT_MODEL_PREVIEW 5
 
+
+/// <summary>Creates a textdraw. Textdraws are, as the name implies, text (mainly - there can be boxes, sprites and model previews (skins/vehicles/weapons/objects too) that is drawn on a player's screens.</summary>
+/// <param name="x">The X (left/right) coordinate to create the textdraw at</param>
+/// <param name="y">The Y (up/down) coordinate to create the textdraw at</param>
+/// <param name="text">The text that will appear in the textdraw</param>
+/// <remarks>
+///   If you choose values for y that are less than 1, the first text row will be invisible and only the shadow is visible.<p/>
+///   text[] must not be empty or the server will crash! If you need a textdraw that shows nothing, use a space underscore. <b>Now it's fixed</b>.<p/>
+///   If the last character in the text is a space, the text will all be blank.<p/>
+///   If part of the text is off-screen, the color of the text will not show, only the shadow (if enabled) will.
+/// </remarks>
+/// <remarks>
+///   <em>This applies ONLY to sa-mp versions before 0.3z:</em><p/>
+///   Maximum length of textdraw is <b>800</b> characters. Longer text will crash the client in older versions.<p/>
+///   If you use color codes (such as <b><c>~R~ ~G~</c></b>) beyond 255th character the client will crash trying to display the textdraw.
+/// </remarks>
+/// <remarks>
+///   The x,y coordinate is the top left coordinate for the text draw area based on a 640x480 "canvas" (irrespective of screen resolution). If you plan on using <a href="#TextDrawAlignment">TextDrawAlignment</a> with alignment <b><c>3</c></b> (right), the x,y coordinate is the top right coordinate for the text draw.<p/>
+///   This function merely CREATES the textdraw, you must use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a> or <a href="#TextDrawShowForAll">TextDrawShowForAll</a> to show it.<p/>
+///   It is recommended to use WHOLE numbers instead of decimal positions when creating textdraws to ensure resolution friendly design.
+/// </remarks>
+/// <remarks>Keyboard key mapping codes (such as <b><c>~k~~VEHICLE_ENTER_EXIT~</c></b> don't work beyond 255th character. </remarks>
+/// <returns>The ID of the created textdraw. Textdraw IDs start at <b><c>0</c></b>.</returns>
 native Text:TextDrawCreate(Float:x, Float:y, text[]);
+
+/// <summary>Destroys a previously-created textdraw.</summary>
+/// <param name="text">The ID of the textdraw to destroy. Returned by <a href="#TextDrawCreate">TextDrawCreate</a></param>
 native TextDrawDestroy(Text:text);
+
+/// <summary>Sets the width and height of the letters.</summary>
+/// <param name="text">The TextDraw to change</param>
+/// <param name="x">Width of a char</param>
+/// <param name="y">Height of a char</param>
+/// <remarks>When using this function purely for the benefit of affecting the TextDraw box, multiply 'Y' by <b><c>0.135</c></b> to convert to <a href="#TextDrawTextSize">TextDrawTextSize</a>-like measurements. <b>Hint</b>: it is easier and extremely precise to use <b><c>LD_SPAC:white</c></b> sprite for box-only textdraws, <a href="#TextDrawTextSize">TextDrawTextSize</a> will have regular offsets.</remarks>
+/// <remarks>If you want to change the letter size of a textdraw that is already shown, you don't have to recreate it. Simply use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>/<a href="#TextDrawShowForAll">TextDrawShowForAll</a> after modifying the textdraw and the change will be visible. </remarks>
+/// <remarks>Fonts appear to look the best with an X to Y ratio of <b><c>1</c></b> to <b><c>4</c></b> (e.g. if x is <b><c>0.5</c></b> then y should be <b><c>2</c></b>). </remarks>
 native TextDrawLetterSize(Text:text, Float:x, Float:y);
+
+/// <summary>Change the size of a textdraw (box if <a href="#TextDrawUseBox">TextDrawUseBox</a> is enabled and/or clickable area for use with <a href="#TextDrawSetSelectable">TextDrawSetSelectable</a>).</summary>
+/// <param name="text">The TextDraw to set the size of</param>
+/// <param name="x">The size on the X axis (left/right) following the same 640x480 grid as <a href="#TextDrawCreate">TextDrawCreate</a></param>
+/// <param name="y">The size on the Y axis (up/down) following the same 640x480 grid as <a href="#TextDrawCreate">TextDrawCreate</a></param>
+/// <remarks>
+///   The x and y have different meanings with different TextDrawAlignment values:<p/>
+///   <ul>
+///     <li><b><c>1</c></b> (left): they are the right-most corner of the box, absolute coordinates.</li>
+///     <li><b><c>2</c></b> (center): they need to inverted (switch the two) and the x value is the overall width of the box.</li>
+///     <li><b><c>3</c></b> (right): the x and y are the coordinates of the left-most corner of the box </li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   Using font type <b><c>4</c></b> (sprite) and <b><c>5</c></b> (model preview) converts X and Y of this function from corner coordinates to WIDTH and HEIGHT (offsets).<p/>
+///   The TextDraw box starts <b><c>10.0</c></b> units up and <b><c>5.0</c></b> to the left as the origin (<a href="#TextDrawCreate">TextDrawCreate</a> coordinate).<p/>
+///   This function defines the clickable area for use with <a href="#TextDrawSetSelectable">TextDrawSetSelectable</a>, whether a box is shown or not.
+/// </remarks>
+/// <remarks>If you want to change the text size of a textdraw that is already shown, you don't have to recreate it. Simply use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>/<a href="#TextDrawShowForAll">TextDrawShowForAll</a> after modifying the textdraw and the change will be visible.</remarks>
 native TextDrawTextSize(Text:text, Float:x, Float:y);
+
+/// <summary>Set the alignment of text in a text draw.</summary>
+/// <param name="text">The ID of the textdraw to set the alignment of</param>
+/// <param name="alignment"><b><c>1</c></b>-left <b><c>2</c></b>-centered <b><c>3</c></b>-right</param>
+/// <remarks>For alignment <b><c>2</c></b> (center) the x and y values of <a href="#TextSize">TextSize</a> need to be swapped, see notes at <a href="#TextDrawTextSize">TextDrawTextSize</a>, also position coordinate become position of center of textdraw and not left/top edges. </remarks>
 native TextDrawAlignment(Text:text, alignment);
+
+/// <summary>Sets the text color of a textdraw.</summary>
+/// <param name="text">The ID of the textdraw to change the color of.</param>
+/// <param name="color">The color to set the textdraw to</param>
+/// <remarks>You can also use GameText Colors in TextDraws.</remarks>
+/// <remarks>If the TextDraw is already shown, it must be re-shown (<a href="#TextDrawShowForAll">TextDrawShowForAll</a>/<a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>) for the changes of this function to take effect.</remarks>
 native TextDrawColor(Text:text, color);
+
+/// <summary>Toggle whether a textdraw uses a box or not.</summary>
+/// <param name="text">The ID of the text textdraw to toggle the box of</param>
+/// <param name="use"><b><c>1</c></b> to show a box or <b><c>0</c></b> to not show a box</param>
+/// <remarks>If the textdraw is already shown, it must be re-shown (<a href="#TextDrawShowForAll">TextDrawShowForAll</a>/<a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>) to show the changes of this function.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the textdraw specified does not exist.
+/// </returns>
 native TextDrawUseBox(Text:text, use);
+
+/// <summary>Adjusts the text box colour (only used if <a href="#TextDrawUseBox">TextDrawUseBox</a> 'use' parameter is <b><c>1</c></b>).</summary>
+/// <param name="text">The TextDraw to change</param>
+/// <param name="color">The colour (<b>RGBA</b>)</param>
+/// <remarks>If you want to change the boxcolour of a textdraw that is already shown, you don't have to recreate it. Simply use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>/<a href="#TextDrawShowForAll">TextDrawShowForAll</a> after modifying the textdraw and the change will be visible.</remarks>
 native TextDrawBoxColor(Text:text, color);
+
+/// <summary>Sets the size of a textdraw's text's shadow.</summary>
+/// <param name="text">The ID of the textdraw to set the shadow size of</param>
+/// <param name="size">The size of the shadow. <b><c>1</c></b> is generally used for a normal shadow size. <b><c>0</c></b> disables the shadow completely</param>
+/// <remarks>The shadow can be cut by the box area if the size is set too big for the area.</remarks>
+/// <remarks>If you want to change the shadow of a textdraw that is already shown, you don't have to recreate it. Simply use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>/<a href="#TextDrawShowForAll">TextDrawShowForAll</a> after modifying the textdraw and the change will be visible.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The textdraw does not exist.
+/// </returns>
 native TextDrawSetShadow(Text:text, size);
+
+/// <summary>Sets the thickness of a textdraw's text's outline. <a href="#TextDrawBackgroundColor">TextDrawBackgroundColor</a> can be used to change the color.</summary>
+/// <param name="text">The ID of the text draw to set the outline thickness of</param>
+/// <param name="size">The thickness of the outline, as an integer. <b><c>0</c></b> for no outline</param>
+/// <remarks>If you want to change the outline of a textdraw that is already shown, you don't have to recreate it. Simply use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>/<a href="#TextDrawShowForAll">TextDrawShowForAll</a> after modifying the textdraw and the change will be visible.</remarks>
 native TextDrawSetOutline(Text:text, size);
+
+/// <summary>Adjusts the text draw area background color (the outline/shadow - NOT the box. For box color, see <a href="#TextDrawBoxColor">TextDrawBoxColor</a>).</summary>
+/// <param name="text">The ID of the textdraw to set the background color of</param>
+/// <param name="color">The color that the textdraw should be set to</param>
+/// <remarks>If <a href="#TextDrawSetOutline">TextDrawSetOutline</a> is used with size &gt; <b><c>0</c></b>, the outline color will match the color used in <a href="#TextDrawBackgroundColor">TextDrawBackgroundColor</a>. Changing the value of color seems to alter the color used in <a href="#TextDrawColor">TextDrawColor</a></remarks>
+/// <remarks>If you want to change the background colour of a textdraw that is already shown, you don't have to recreate it. Simply use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>/<a href="#TextDrawShowForAll">TextDrawShowForAll</a> after modifying the textdraw and the change will be visible.</remarks>
 native TextDrawBackgroundColor(Text:text, color);
+
+/// <summary>Changes the text font.</summary>
+/// <param name="text">The TextDraw to change</param>
+/// <param name="font">There are four font styles, see <a href="http://wiki.sa-mp.com/wiki/PlayerTextDrawFont">http://wiki.sa-mp.com/wiki/PlayerTextDrawFont</a>. Font value <b><c>4</c></b> specifies that this is a txd sprite; <b><c>5</c></b> specifies that this textdraw can display preview models. A font value greater than 5 does not display, and anything greater than 16 crashes the client</param>
+/// <remarks>If you want to change the font of a textdraw that is already shown, you don't have to recreate it. Simply use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>/<a href="#TextDrawShowForAll">TextDrawShowForAll</a> after modifying the textdraw and the change will be visible.</remarks>
 native TextDrawFont(Text:text, font);
+
+/// <summary>Appears to scale text spacing to a proportional ratio. Useful when using <a href="#TextDrawLetterSize">TextDrawLetterSize</a> to ensure the text has even character spacing.</summary>
+/// <param name="text">The ID of the textdraw to set the proportionality of</param>
+/// <param name="set"><b><c>1</c></b> to enable proportionality, <b><c>0</c></b> to disable</param>
+/// <remarks>Proportionality is set to <b><c>1</c></b> by default, you might skip this function if you don't want to disable it. </remarks>
+/// <remarks>If you want to change the proportionality of a textdraw that is already shown, you don't have to recreate it. Simply use <a href="#TextDrawShowForPlayer">TextDrawShowForPlayer</a>/<a href="#TextDrawShowForAll">TextDrawShowForAll</a> after modifying the textdraw and the change will be visible. </remarks>
 native TextDrawSetProportional(Text:text, set);
+
+/// <summary>Sets whether a textdraw can be selected (clicked on) or not.</summary>
+/// <param name="text">The ID of the textdraw to make selectable</param>
+/// <param name="set"><b><c>1</c></b> to make it selectable, or <b><c>0</c></b> to make it not selectable</param>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks><a href="#TextDrawSetSelectable">TextDrawSetSelectable</a> must be used BEFORE the textdraw is shown to players for it to be selectable.</remarks>
+/// <remarks>Use <a href="#TextDrawTextSize">TextDrawTextSize</a> to define the clickable area.</remarks>
 native TextDrawSetSelectable(Text:text, set);
+
+/// <summary>Shows a textdraw for a specific player.</summary>
+/// <param name="playerid">The ID of the player to show the textdraw for</param>
+/// <param name="text">The ID of the textdraw to show. Returned by <a href="#TextDrawCreate">TextDrawCreate</a></param>
+/// <remarks>If only a single player will see a textdraw, it might be wise to use player-textdraws instead. This is also useful for textdraws that need to show information specific for an individual player.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means either the player and/or textdraw specified does not exist.
+/// </returns>
 native TextDrawShowForPlayer(playerid, Text:text);
+
+/// <summary>Hides a textdraw for a specific player.</summary>
+/// <param name="playerid">The ID of the player that the textdraw should be hidden for</param>
+/// <param name="text">The ID of the textdraw to hide</param>
+/// <seealso name="TextDrawHideForAll"/>
+/// <seealso name="TextDrawShowForPlayer"/>
+/// <seealso name="TextDrawShowForAll"/>
 native TextDrawHideForPlayer(playerid, Text:text);
+
+/// <summary>Shows a textdraw for all players.</summary>
+/// <param name="text">The ID of the textdraw to show. Returned by <a href="#TextDrawCreate">TextDrawCreate</a></param>
+/// <seealso name="TextDrawShowForPlayer"/>
+/// <seealso name="TextDrawHideForPlayer"/>
+/// <seealso name="TextDrawHideForAll"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the textdraw specified does not exist.
+/// </returns>
 native TextDrawShowForAll(Text:text);
+
+/// <summary>Hides a text draw for all players.</summary>
+/// <param name="text">The ID of the textdraw to hide (returned by <a href="#TextDrawCreate">TextDrawCreate</a>)</param>
+/// <seealso name="TextDrawShowForPlayer"/>
+/// <seealso name="TextDrawHideForPlayer"/>
+/// <seealso name="TextDrawShowForAll"/>
 native TextDrawHideForAll(Text:text);
+
+/// <summary>Changes the text on a textdraw.</summary>
+/// <param name="text">The TextDraw to change</param>
+/// <param name="string">The new string for the TextDraw</param>
+/// <remarks>There are limits to the length of textdraw strings - see <a href="http://wiki.sa-mp.com/wiki/Limits">here</a> for more info.</remarks>
 native TextDrawSetString(Text:text, string[]);
+
+/// <summary>Set the model for a textdraw model preview. Click <a href="http://www.sa-mp.com/stuff/03xShots/pmenu.png">here</a> to see this function's effect.</summary>
+/// <param name="text">The textdraw id that will display the 3D preview</param>
+/// <param name="modelindex">The GTA SA or SA:MP model ID to display</param>
+/// <remarks>This function was added in <b>SA-MP 0.3x</b> and will not work in earlier versions!</remarks>
+/// <remarks>The textdraw MUST use the font type <b><c>TEXT_DRAW_FONT_MODEL_PREVIEW</c></b> in order for this function to have effect.</remarks>
+/// <remarks>Use <a href="#TextDrawBackgroundColor">TextDrawBackgroundColor</a> to set the background color behind the model.</remarks>
 native TextDrawSetPreviewModel(Text:text, modelindex);
+
+/// <summary>Sets the rotation and zoom of a 3D model preview textdraw.</summary>
+/// <param name="fRotX">The X rotation value</param>
+/// <param name="fRotY">The Y rotation value</param>
+/// <param name="fRotZ">The Z rotation value</param>
+/// <param name="fZoom">The zoom value, smaller values make the camera closer and larger values make the camera further away (optional=<b><c>1.0</c></b>)</param>
+/// <remarks>This function was added in <b>SA-MP 0.3x</b> and will not work in earlier versions!</remarks>
+/// <remarks>The textdraw MUST use the font type <b><c>TEXT_DRAW_FONT_MODEL_PREVIEW</c></b> in order for this function to have effect.</remarks>
 native TextDrawSetPreviewRot(Text:text, Float:fRotX, Float:fRotY, Float:fRotZ, Float:fZoom = 1.0);
+
+/// <summary>If a vehicle model is used in a 3D preview textdraw, this sets the two colour values for that vehicle.</summary>
+/// <param name="text">The textdraw id that is set to display a 3D vehicle model preview</param>
+/// <param name="color1">The primary Color ID to set the vehicle to</param>
+/// <param name="color2">The secondary Color ID to set the vehicle to</param>
+/// <remarks>This function was added in <b>SA-MP 0.3x</b> and will not work in earlier versions!</remarks>
+/// <remarks>The textdraw MUST use the font type <b><c>TEXT_DRAW_FONT_MODEL_PREVIEW</c></b> in order for this function to have effect.</remarks>
 native TextDrawSetPreviewVehCol(Text:text, color1, color2);
 
 // Gang Zones
+
+/// <summary>Create a gangzone (colored radar area).</summary>
+/// <param name="minx">The X coordinate for the west side of the gangzone</param>
+/// <param name="miny">The Y coordinate for the south side of the gangzone</param>
+/// <param name="maxx">The X coordinate for the east side of the gangzone</param>
+/// <param name="maxy">The Y coordinate for the north side of the gangzone</param>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
+/// <remarks>
+///   There is a limit of <b><c>1024</c></b> gangzones.<p/>
+///   Putting the parameters in the wrong order results in glitchy behavior.
+/// </remarks>
+/// <remarks>This function merely CREATES the gangzone, you must use <a href="#GangZoneShowForPlayer">GangZoneShowForPlayer</a> or <a href="#GangZoneShowForAll">GangZoneShowForAll</a> to show it.</remarks>
+/// <returns>The ID of the created zone, returns <b><c>-1</c></b> if not created.</returns>
 native GangZoneCreate(Float:minx, Float:miny, Float:maxx, Float:maxy);
+
+/// <summary>Destroy a gangzone.</summary>
+/// <param name="zone">The ID of the zone to destroy</param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
 native GangZoneDestroy(zone);
+
+/// <summary>Show a gangzone for a player. Must be created with <a href="#GangZoneCreate">GangZoneCreate</a> first.</summary>
+/// <param name="playerid">The ID of the player you would like to show the gangzone for.</param>
+/// <param name="zone">The ID of the gang zone to show for the player. Returned by <a href="#GangZoneCreate">GangZoneCreate</a></param>
+/// <param name="color">The color to show the gang zone, as an integer or hex in <b>RGBA</b> color format. Alpha transparency supported</param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
+/// <returns><b><c>1</c></b> if the gangzone was shown, otherwise <b><c>0</c></b> (non-existant).</returns>
 native GangZoneShowForPlayer(playerid, zone, color);
+
+/// <summary>Shows a gangzone with the desired color to all players.</summary>
+/// <param name="zone">The ID of the gangzone to show (returned by <a href="# GangZoneCreate">GangZoneCreate</a>)</param>
+/// <param name="color">The color to show the gang zone, as an integer or hex in <b>RGBA</b> color format. Alpha transparency supported</param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. The gang zone was shown for all players.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The gangzone does not exist.
+/// </returns>
 native GangZoneShowForAll(zone, color);
+
+/// <summary>Hides a gangzone for a player.</summary>
+/// <param name="playerid">The ID of the player to hide the gangzone for</param>
+/// <param name="zone">The ID of the zone to hide</param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
 native GangZoneHideForPlayer(playerid, zone);
+
+/// <summary>GangZoneHideForAll hides a gangzone from all players.</summary>
+/// <param name="zone">The zone to hide</param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
 native GangZoneHideForAll(zone);
+
+/// <summary>Makes a gangzone flash for a player.</summary>
+/// <param name="playerid">The ID of the player to flash the gangzone for</param>
+/// <param name="zone">The ID of the zone to flash</param>
+/// <param name="flashcolor">The color to flash the gang zone, as an integer or hex in <b>RGBA</b> color format. Alpha transparency supported</param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
 native GangZoneFlashForPlayer(playerid, zone, flashcolor);
+
+/// <summary>GangZoneFlashForAll flashes a gangzone for all players.</summary>
+/// <param name="zone">The zone to flash</param>
+/// <param name="flashcolor">The color to flash the gang zone, as an integer or hex in <b>RGBA</b> color format. Alpha transparency supported</param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
 native GangZoneFlashForAll(zone, flashcolor);
+
+/// <summary>Stops a gangzone flashing for a player.</summary>
+/// <param name="playerid">The ID of the player to stop the gangzone flashing for</param>
+/// <param name="zone">The ID of the gangzonezone to stop flashing</param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForAll"/>
 native GangZoneStopFlashForPlayer(playerid, zone);
+
+/// <summary>Stops a gangzone flashing for all players.</summary>
+/// <param name="zone">The ID of the zone to stop flashing. Returned by <a href="#GangZoneCreate">GangZoneCreate</a></param>
+/// <seealso name="GangZoneCreate"/>
+/// <seealso name="GangZoneDestroy"/>
+/// <seealso name="GangZoneShowForPlayer"/>
+/// <seealso name="GangZoneShowForAll"/>
+/// <seealso name="GangZoneHideForPlayer"/>
+/// <seealso name="GangZoneHideForAll"/>
+/// <seealso name="GangZoneFlashForPlayer"/>
+/// <seealso name="GangZoneFlashForAll"/>
+/// <seealso name="GangZoneStopFlashForPlayer"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. Success is reported even if the gang zone wasn't flashing to begin with.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The gangzone specified does not exist.
+/// </returns>
 native GangZoneStopFlashForAll(zone);
 
 // Global 3D Text Labels
+
+/// <summary>Creates a 3D Text Label at a specific location in the world.</summary>
+/// <param name="text">The initial text string</param>
+/// <param name="color">The text Color, as an integer or hex in <b>RGBA</b> color format</param>
+/// <param name="X">X-Coordinate</param>
+/// <param name="Y">Y-Coordinate</param>
+/// <param name="Z">Z-Coordinate</param>
+/// <param name="DrawDistance">The distance from where you are able to see the 3D Text Label</param>
+/// <param name="virtualworld">The virtual world in which you are able to see the 3D Text</param>
+/// <param name="testLOS">Test the line-of-sight so this text can't be seen through objects (optional=<b><c>0</c></b>)</param>
+/// <seealso name="Delete3DTextLabel"/>
+/// <seealso name="Attach3DTextLabelToPlayer"/>
+/// <seealso name="Attach3DTextLabelToVehicle"/>
+/// <seealso name="Update3DTextLabelText"/>
+/// <seealso name="CreatePlayer3DTextLabel"/>
+/// <seealso name="DeletePlayer3DTextLabel"/>
+/// <seealso name="UpdatePlayer3DTextLabelText"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   If <paramref name="text"/> is empty, the server/clients next to the text might crash!<p/>
+///   If the virtualworld is set as <b><c>-1</c></b> the text will not appear.
+/// </remarks>
+/// <remarks>drawdistance seems to be a lot smaller when spectating.</remarks>
+/// <remarks>Use <a href="http://wiki.sa-mp.com/wiki/Colors_List#Inline_color_embedding">color embedding</a> for multiple colors in the text.</remarks>
+/// <returns>The ID of the newly created 3D Text Label, or <b><c>INVALID_3DTEXT_ID</c></b> if the 3D Text Label limit (<b><c>MAX_3DTEXT_GLOBAL</c></b>) was reached.</returns>
 native Text3D:Create3DTextLabel(text[], color, Float:X, Float:Y, Float:Z, Float:DrawDistance, virtualworld, testLOS=0);
+
+/// <summary>Delete a 3D text label (created with <a href="#Create3DTextLabel">Create3DTextLabel</a>).</summary>
+/// <param name="id">The ID of the 3D text label to delete</param>
+/// <seealso name="Create3DTextLabel"/>
+/// <seealso name="Attach3DTextLabelToPlayer"/>
+/// <seealso name="Attach3DTextLabelToVehicle"/>
+/// <seealso name="Update3DTextLabelText"/>
+/// <seealso name="CreatePlayer3DTextLabel"/>
+/// <seealso name="DeletePlayer3DTextLabel"/>
+/// <seealso name="UpdatePlayer3DTextLabelText"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>1</c></b> if the 3D text label was deleted, otherwise <b><c>0</c></b>.</returns>
 native Delete3DTextLabel(Text3D:id);
+
+/// <summary>Attach a 3D text label to a player.</summary>
+/// <param name="id">The ID of the 3D text label to attach. Returned by <a href="#Create3DTextLabel">Create3DTextLabel</a></param>
+/// <param name="playerid">The ID of the player to attach the label to</param>
+/// <param name="OffsetX">The X offset from the player</param>
+/// <param name="OffsetY">The Y offset from the player</param>
+/// <param name="OffsetZ">The Z offset from the player</param>
+/// <seealso name="Create3DTextLabel"/>
+/// <seealso name="Delete3DTextLabel"/>
+/// <seealso name="Attach3DTextLabelToVehicle"/>
+/// <seealso name="Update3DTextLabelText"/>
+/// <seealso name="CreatePlayer3DTextLabel"/>
+/// <seealso name="DeletePlayer3DTextLabel"/>
+/// <seealso name="UpdatePlayer3DTextLabelText"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>
+/// <b><c>1</c></b>: The function executed successfully.<p/>
+/// <b><c>0</c></b>: The function failed to execute. This means the player and/or label do not exist.
+/// </returns>
 native Attach3DTextLabelToPlayer(Text3D:id, playerid, Float:OffsetX, Float:OffsetY, Float:OffsetZ);
+
+/// <summary>Attaches a 3D Text Label to a specific vehicle.</summary>
+/// <param name="id">The ID of the 3D text label to attach. Returned by <a href="#Create3DTextLabel">Create3DTextLabel</a></param>
+/// <param name="vehicleid">The vehicle you want to attach the 3D Text Label to</param>
+/// <param name="OffsetX">The Offset-X coordinate of the player vehicle (the vehicle is 0.0,0.0,0.0).</param>
+/// <param name="OffsetY">The Offset-Y coordinate of the player vehicle (the vehicle is 0.0,0.0,0.0).</param>
+/// <param name="OffsetZ">The Offset-Z coordinate of the player vehicle (the vehicle is 0.0,0.0,0.0).</param>
+/// <seealso name="Create3DTextLabel"/>
+/// <seealso name="Delete3DTextLabel"/>
+/// <seealso name="Attach3DTextLabelToPlayer"/>
+/// <seealso name="Update3DTextLabelText"/>
+/// <seealso name="CreatePlayer3DTextLabel"/>
+/// <seealso name="DeletePlayer3DTextLabel"/>
+/// <seealso name="UpdatePlayer3DTextLabelText"/>
+/// <remarks>Attach3DTextLabelToPlayer was added in SA-MP 0.3a 	This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
 native Attach3DTextLabelToVehicle(Text3D:id, vehicleid, Float:OffsetX, Float:OffsetY, Float:OffsetZ);
+
+
+/// <summary>Updates a 3D Text Label text and color.</summary>
+/// <param name="id">The 3D Text Label you want to update</param>
+/// <param name="color">The color the 3D Text Label should have from now on</param>
+/// <param name="text">The new text which the 3D Text Label should have from now on</param>
+/// <seealso name="Create3DTextLabel"/>
+/// <seealso name="Delete3DTextLabel"/>
+/// <seealso name="Attach3DTextLabelToPlayer"/>
+/// <seealso name="Attach3DTextLabelToVehicle"/>
+/// <seealso name="CreatePlayer3DTextLabel"/>
+/// <seealso name="DeletePlayer3DTextLabel"/>
+/// <seealso name="UpdatePlayer3DTextLabelText"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>If <paramref name="text"/> is empty, the server/clients next to the text might crash!</remarks>
 native Update3DTextLabelText(Text3D:id, color, text[]);
 
 // Per-player 3D Text Labels
+
+/// <summary>Creates a 3D Text Label only for a specific player.</summary>
+/// <param name="playerid">The player which should see the newly created 3DText Label</param>
+/// <param name="text">The text to display</param>
+/// <param name="color">The text color</param>
+/// <param name="X">X Coordinate (or offset if attached)</param>
+/// <param name="Y">Y Coordinate (or offset if attached)</param>
+/// <param name="Z">Z Coordinate (or offset if attached)</param>
+/// <param name="DrawDistance">The distance where you are able to see the 3D Text Label</param>
+/// <param name="attachedplayer">The player you want to attach the 3D Text Label to. (optional=<b><c>INVALID_PLAYER_ID</c></b>)</param>
+/// <param name="attachedvehicle">The vehicle you want to attach the 3D Text Label to. (optional=<b><c>INVALID_VEHICLE_ID</c></b>)</param>
+/// <param name="testLOS">Test the line-of-sight so this text can't be seen through walls (optional=<b><c>0</c></b>)</param>
+/// <seealso name="Create3DTextLabel"/>
+/// <seealso name="Delete3DTextLabel"/>
+/// <seealso name="Attach3DTextLabelToPlayer"/>
+/// <seealso name="Attach3DTextLabelToVehicle"/>
+/// <seealso name="Update3DTextLabelText"/>
+/// <seealso name="DeletePlayer3DTextLabel"/>
+/// <seealso name="UpdatePlayer3DTextLabelText"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>If <paramref name="text"/> is empty, the server/clients next to the text might crash!</remarks>
+/// <remarks>drawdistance seems to be a lot smaller when spectating.</remarks>
+/// <returns>The ID of the newly created Player 3D Text Label, or <b><c>INVALID_3DTEXT_ID</c></b> if the Player 3D Text Label limit (<b><c>MAX_3DTEXT_PLAYER</c></b>) was reached.</returns>
 native PlayerText3D:CreatePlayer3DTextLabel(playerid, text[], color, Float:X, Float:Y, Float:Z, Float:DrawDistance, attachedplayer=INVALID_PLAYER_ID, attachedvehicle=INVALID_VEHICLE_ID, testLOS=0);
+
+/// <summary>Destroy a 3D text label that was created using <a href="#CreatePlayer3DTextLabel">CreatePlayer3DTextLabel</a>.</summary>
+/// <param name="playerid">The ID of the player whose 3D text label to delete</param>
+/// <param name="id">The ID of the player's 3D text label to delete</param>
+/// <seealso name="Create3DTextLabel"/>
+/// <seealso name="Attach3DTextLabelToPlayer"/>
+/// <seealso name="Attach3DTextLabelToVehicle"/>
+/// <seealso name="Update3DTextLabelText"/>
+/// <seealso name="CreatePlayer3DTextLabel"/>
+/// <seealso name="UpdatePlayer3DTextLabelText"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the label specified doesn't exist.
+/// </returns>
 native DeletePlayer3DTextLabel(playerid, PlayerText3D:id);
+
+/// <summary>Updates a player 3D Text Label's text and color.</summary>
+/// <param name="playerid">The ID of the player for which the 3D Text Label was created</param>
+/// <param name="id">The 3D Text Label you want to update</param>
+/// <param name="color">The color the 3D Text Label should have from now on</param>
+/// <param name="text">The new text which the 3D Text Label should have from now on</param>
+/// <seealso name="Create3DTextLabel"/>
+/// <seealso name="Delete3DTextLabel"/>
+/// <seealso name="Attach3DTextLabelToPlayer"/>
+/// <seealso name="Attach3DTextLabelToVehicle"/>
+/// <seealso name="Update3DTextLabelText"/>
+/// <seealso name="CreatePlayer3DTextLabel"/>
+/// <seealso name="DeletePlayer3DTextLabel"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>If <paramref name="text"/> is empty, the server/clients next to the text might crash!</remarks>
 native UpdatePlayer3DTextLabelText(playerid, PlayerText3D:id, color, text[]);
 
 // Player GUI Dialog
@@ -254,6 +1923,24 @@ native UpdatePlayer3DTextLabelText(playerid, PlayerText3D:id, color, text[]);
 #define DIALOG_STYLE_TABLIST			4
 #define DIALOG_STYLE_TABLIST_HEADERS	5
 
+
+/// <summary>Shows the player a synchronous (only one at a time) dialog box.</summary>
+/// <param name="playerid">The ID of the player to show the dialog to</param>
+/// <param name="dialogid">An ID to assign this dialog to, so responses can be processed. Max dialogid is <b><c>32767</c></b>. Using negative values will close any open dialog</param>
+/// <param name="style">The style of the dialog</param>
+/// <param name="caption">The title at the top of the dialog. The length of the caption can not exceed more than 64 characters before it starts to cut off</param>
+/// <param name="info">The text to display in the main dialog. Use <b><c>\n</c></b> to start a new line and <b><c>\t</c></b> to tabulate</param>
+/// <param name="button1">The text on the left button</param>
+/// <param name="button2">The text on the right button. Leave it blank ( "" ) to hide it</param>
+/// <seealso name="TextDrawShowForPlayer"/>
+/// <seealso name="OnDialogResponse"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>Use color embedding for multiple colors in the text. </remarks>
+/// <remarks>Using <b><c>-1</c></b> as dialogid closes all dialogs currently shown on the client's screen. </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the player is not connected.<p/>
+/// </returns>
 native ShowPlayerDialog(playerid, dialogid, style, caption[], info[], button1[], button2[]);
 
 // --------------------------------------------------
@@ -353,72 +2040,919 @@ native ShowPlayerDialog(playerid, dialogid, style, caption[], info[], button1[],
 // Forwards (Callback declarations)
 // --------------------------------------------------
 
+
+/// <summary>This callback is triggered when the gamemode starts.</summary>
+/// <seealso name="OnGameModeExit"/>
+/// <seealso name="OnFilterScriptInit"/>
+/// <seealso name="OnFilterScriptExit"/>
+/// <remarks>This function can also be used in a filterscript to detect if the gamemode changes with RCON commands like changemode or gmx, as changing the gamemode does not reload a filterscript.</remarks>
+/// <returns>
+///   <b><c>0</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>1</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in gamemode.
+/// </returns>
 forward OnGameModeInit();
+
+/// <summary>This callback is called when a gamemode ends, either through 'gmx', the server being shut down, or <a href="#GameModeExit">GameModeExit</a>.</summary>
+/// <seealso name="OnGameModeInit"/>
+/// <seealso name="OnFilterScriptExit"/>
+/// <seealso name="OnFilterScriptInit"/>
+/// <seealso name="GameModeExit"/>
+/// <remarks>This function can also be used in a filterscript to detect if the gamemode changes with RCON commands like changemode or gmx, as changing the gamemode does not reload a filterscript.</remarks>
+/// <remarks>When using OnGameModeExit in conjunction with the 'rcon gmx' console command keep in mind there is a potential for client bugs to occur an example of this is excessive <a href="#RemoveBuildingForPlayer">RemoveBuildingForPlayer</a> calls during OnGameModeInit which could result in a client crash. </remarks>
+/// <remarks>This callback will NOT be called if the server crashes or the process is killed by other means, such as using the Linux kill command or pressing the close-button on the Windows console. </remarks>
+/// <returns>
+///   <b><c>0</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>1</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in gamemode.
+/// </returns>
 forward OnGameModeExit();
+
+/// <summary>This callback is called when a filterscript is initialized (loaded). It is only called inside the filterscript which is starting.</summary>
+/// <seealso name="OnFilterScriptExit"/>
+/// <seealso name="OnGameModeInit"/>
+/// <seealso name="OnGameModeExit"/>
+/// <returns>This callback does not handle returns.</returns>
 forward OnFilterScriptInit();
+
+/// <summary>This callback is called when a filterscript is unloaded. It is only called inside the filterscript which is unloaded.</summary>
+/// <seealso name="OnFilterScriptInit"/>
+/// <seealso name="OnGameModeInit"/>
+/// <seealso name="OnGameModeExit"/>
+/// <returns>This callback does not handle returns.</returns>
 forward OnFilterScriptExit();
+
+/// <summary>This callback is called when a player connects to the server.</summary>
+/// <param name="playerid">The ID of the player that connected</param>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <seealso name="OnIncomingConnection"/>
+/// <seealso name="OnPlayerFinishedDownloading"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   <b><c>0</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>1</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerConnect(playerid);
+
+/// <summary>This callback is called when a player disconnects from the server.</summary>
+/// <param name="playerid">The ID of the player that disconnected</param>
+/// <param name="reason">The reason for the disconnection. See table below</param>
+/// <seealso name="OnPlayerConnect"/>
+/// <seealso name="OnIncomingConnection"/>
+/// <seealso name="OnPlayerFinishedDownloading"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>Some functions might not work correctly when used in this callback because the player is already disconnected when the callback is called. This means that you can't get unambiguous information from functions like <a href="#GetPlayerIp">GetPlayerIp</a> and <a href="#GetPlayerPos">GetPlayerPos</a>.</remarks>
+/// <remarks>
+///   <b>Reasons:</b><p/>
+///   <ul>
+///     <li><b><c>0</c></b> - timeout/Crash - the player's connection was lost. Either their game crashed or their network had a fault.</li>
+///     <li><b><c>1</c></b> - quit - the player purposefully quit, either using the <b><c>/quit (/q)</c></b> command or via the pause menu.</li>
+///     <li><b><c>2</c></b> - kick/ban - the player was kicked or banned by the server.</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>0</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>1</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerDisconnect(playerid, reason);
+
+/// <summary>This callback is called when a player spawns.(i.e. after caling <a href="#SpawnPlayer">SpawnPlayer</a> function).</summary>
+/// <param name="playerid">The ID of the player that spawned</param>
+/// <seealso name="OnPlayerDeath"/>
+/// <seealso name="OnVehicleSpawn"/>
+/// <seealso name="SpawnPlayer"/>
+/// <seealso name="AddPlayerClass"/>
+/// <seealso name="SetSpawnInfo"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>The game sometimes deducts $100 from players after spawn.</remarks>
+/// <returns>
+///   <b><c>0</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>1</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerSpawn(playerid);
+
+/// <summary>This callback is called when a player dies, either by suicide or by being killed by another player.</summary>
+/// <param name="playerid">The ID of the player that died</param>
+/// <param name="killerid">The ID of the player that killed the player who died, or <b><c>INVALID_PLAYER_ID</c></b> if there was none</param>
+/// <param name="reason">The ID of the <a href="http://wiki.sa-mp.com/wiki/Weapons">reason</a> for the player's death</param>
+/// <seealso name="OnPlayerSpawn"/>
+/// <seealso name="SendDeathMessage"/>
+/// <seealso name="SetPlayerHealth"/>
+/// <remarks>
+///   The reason will return 37 (flame thrower) from any fire sources (e.g. molotov, 18)<p/>
+///   The reason will return 51 from any weapon that creates an explosion (e.g. RPG, grenade)<p/>
+///   You do not need to check whether killerid is valid before using it in <a href="#SendDeathMessage">SendDeathMessage</a>. <b><c>INVALID_PLAYER_ID</c></b> is a valid killerid ID parameter in that function.<p/>
+///   <b>playerid</b> is the only one who can call the callback. (good to know for anti fake death)
+/// </remarks>
+/// <returns>
+///   <b><c>0</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>1</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerDeath(playerid, killerid, reason);
+
+/// <summary>This callback is called when a vehicle <b>re</b>spawns.</summary>
+/// <param name="vehicleid">The ID of the vehicle that spawned</param>
+/// <seealso name="OnVehicleDeath"/>
+/// <seealso name="OnPlayerSpawn"/>
+/// <seealso name="SetVehicleToRespawn"/>
+/// <seealso name="CreateVehicle"/>
+/// <returns>
+///   <b><c>0</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>1</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnVehicleSpawn(vehicleid);
+
+/// <summary>This callback is called when a vehicle is destroyed - either by exploding or becoming submerged in water.</summary>
+/// <param name="vehicleid">The ID of the vehicle that was destroyed</param>
+/// <param name="killerid">The ID of the player that reported (synced) the vehicle's destruction (name is misleading). Generally the driver or a passenger (if any) or the closest player</param>
+/// <seealso name="OnVehicleSpawn"/>
+/// <seealso name="SetVehicleHealth"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>This callback will also be called when a vehicle enters water, but the vehicle can be saved from destruction by teleportation or driving out (if only partially submerged). The callback won't be called a second time, and the vehicle may disappear when the driver exits, or after a short time.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnVehicleDeath(vehicleid, killerid);
+
+/// <summary>Called when a player sends a chat message.</summary>
+/// <param name="playerid">The ID of the player who typed the text</param>
+/// <param name="text">The text the player typed</param>
+/// <seealso name="OnPlayerCommandText"/>
+/// <seealso name="SendPlayerMessageToPlayer"/>
+/// <seealso name="SendPlayerMessageToAll"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   Returning <b><c>0</c></b> in this callback will stop the text from being sent to all players.<p/>
+///   It is always called first in filterscripts so returning <b><c>0</c></b> there blocks other scripts from seeing it.
+/// </returns>
 forward OnPlayerText(playerid, text[]);
+
+/// <summary>This callback is called when a player enters a command into the client chat window. Commands are anything that start with a forward slash, e.g. <c>/help</c>.</summary>
+/// <param name="playerid">The ID of the player that entered a command</param>
+/// <param name="cmdtext">The command that was entered (including the forward slash)</param>
+/// <seealso name="OnPlayerText"/>
+/// <seealso name="OnRconCommand"/>
+/// <seealso name="SendRconCommand"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   Return <b><c>1</c></b> if the command was processed, otherwise <b><c>0</c></b>; If the command was not found both in filterscripts and in gamemode, the player will be received a message: <em>SERVER: Unknown command</em>.<p/>
+///   It is always called first in filterscripts so returning <b><c>1</c></b> there blocks other scripts from seeing it.
+/// </returns>
 forward OnPlayerCommandText(playerid, cmdtext[]);
+
+/// <summary>Called when a player changes class at class selection (and when class selection first appears).</summary>
+/// <param name="playerid">The ID of the player that changed class</param>
+/// <param name="classid">The ID of the current class being viewed (returned by <a href="#AddPlayerClass">AddPlayerClass</a>)</param>
+/// <seealso name="OnPlayerRequestSpawn"/>
+/// <seealso name="AddPlayerClass"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>This callback is also called when a player presses <b>F4</b>.</remarks>
+/// <returns>
+///   Returning <b><c>0</c></b> in this callback will prevent the player from spawning. The player can be forced to spawn when <a href="#SpawnPlayer">SpawnPlayer</a> is used.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerRequestClass(playerid, classid);
+
+/// <summary>This callback is called when a player <b><c>starts</c></b> to enter a vehicle, meaning the player is not in vehicle yet at the time this callback is called.</summary>
+/// <param name="playerid">ID of the player who attempts to enter a vehicle</param>
+/// <param name="vehicleid">ID of the vehicle the player is attempting to enter</param>
+/// <param name="ispassenger"><b><c>0</c></b> if entering as driver. <b><c>1</c></b> if entering as passenger</param>
+/// <seealso name="OnPlayerExitVehicle"/>
+/// <seealso name="OnPlayerStateChange"/>
+/// <seealso name="PutPlayerInVehicle"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <remarks>This callback is called when a player <b>BEGINS</b> to enter a vehicle, not when they HAVE entered it. See <a href="#OnPlayerStateChange">OnPlayerStateChange</a>. </remarks>
+/// <remarks>This callback is still called if the player is denied entry to the vehicle (e.g. it is locked or full). </remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerEnterVehicle(playerid, vehicleid, ispassenger);
+
+/// <summary>This callback is called when a player <b>starts</b> to exit a vehicle.</summary>
+/// <param name="playerid">The ID of the player that is exiting a vehicle</param>
+/// <param name="vehicleid">The ID of the vehicle the player is exiting</param>
+/// <seealso name="OnPlayerEnterVehicle"/>
+/// <seealso name="OnPlayerStateChange"/>
+/// <seealso name="RemovePlayerFromVehicle"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <remarks>Not called if the player falls off a bike or is removed from a vehicle by other means such as using <a href="#SetPlayerPos">SetPlayerPos</a>.</remarks>
+/// <remarks>You must use <a href="#OnPlayerStateChange">OnPlayerStateChange</a> and check if their old state is <b><c>PLAYER_STATE_DRIVER</c></b> or <b><c>PLAYER_STATE_PASSENGER</c></b> and their new state is <b><c>PLAYER_STATE_ONFOOT</c></b>.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerExitVehicle(playerid, vehicleid);
+
+/// <summary>This callback is called when a player changes state. For example, when a player changes from being the driver of a vehicle to being on-foot.</summary>
+/// <param name="playerid">The ID of the player that changed state</param>
+/// <param name="newstate">The player's new state</param>
+/// <param name="oldstate">The player's previous state</param>
+/// <seealso name="OnPlayerInteriorChange"/>
+/// <seealso name="GetPlayerState"/>
+/// <seealso name="GetPlayerSpecialAction"/>
+/// <seealso name="SetPlayerSpecialAction"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>
+///   <b>States:</b><p/>
+///   <ul>
+///     <li><b><c>PLAYER_STATE_NONE</c></b> - empty (while initializing)</li>
+///     <li><b><c>PLAYER_STATE_ONFOOT</c></b> - player is on foot</li>
+///     <li><b><c>PLAYER_STATE_DRIVER</c></b> - player is the driver of a vehicle</li>
+///     <li><b><c>PLAYER_STATE_PASSENGER</c></b> - player is passenger of a vehicle</li>
+///     <li><b><c>PLAYER_STATE_WASTED</c></b> - player is dead or on class selection</li>
+///     <li><b><c>PLAYER_STATE_SPAWNED</c></b> - player is spawned</li>
+///     <li><b><c>PLAYER_STATE_SPECTATING</c></b> - player is spectating</li>
+///     <li><b><c>PLAYER_STATE_EXIT_VEHICLE</c></b> - player exits a vehicle</li>
+///     <li><b><c>PLAYER_STATE_ENTER_VEHICLE_DRIVER</c></b> - player enters a vehicle as driver</li>
+///     <li><b><c>PLAYER_STATE_ENTER_VEHICLE_PASSENGER</c></b> - player enters a vehicle as passenger </li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerStateChange(playerid, newstate, oldstate);
+
+/// <summary>This callback is called when a player enters the checkpoint set for that player.</summary>
+/// <param name="playerid">The player who entered the checkpoint</param>
+/// <seealso name="OnPlayerLeaveCheckpoint"/>
+/// <seealso name="OnPlayerEnterRaceCheckpoint"/>
+/// <seealso name="OnPlayerLeaveRaceCheckpoint"/>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="DisablePlayerCheckpoint"/>
+/// <seealso name="IsPlayerInCheckpoint"/>
+/// <seealso name="SetPlayerRaceCheckpoint"/>
+/// <seealso name="DisablePlayerRaceCheckpoint"/>
+/// <seealso name="IsPlayerInRaceCheckpoint"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerEnterCheckpoint(playerid);
+
+/// <summary>This callback is called when a player leaves the checkpoint set for them by <a href="#SetPlayerCheckpoint">SetPlayerCheckpoint</a>. Only one checkpoint can be set at a time.</summary>
+/// <param name="playerid">The ID of the player that left their checkpoint</param>
+/// <seealso name="OnPlayerEnterCheckpoint"/>
+/// <seealso name="OnPlayerEnterRaceCheckpoint"/>
+/// <seealso name="OnPlayerLeaveRaceCheckpoint"/>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="DisablePlayerCheckpoint"/>
+/// <seealso name="IsPlayerInCheckpoint"/>
+/// <seealso name="SetPlayerRaceCheckpoint"/>
+/// <seealso name="DisablePlayerRaceCheckpoint"/>
+/// <seealso name="IsPlayerInRaceCheckpoint"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerLeaveCheckpoint(playerid);
+
+/// <summary>This callback is called when a player enters a race checkpoint.</summary>
+/// <param name="playerid">The ID of the player who entered the race checkpoint</param>
+/// <seealso name="OnPlayerEnterCheckpoint"/>
+/// <seealso name="OnPlayerLeaveCheckpoint"/>
+/// <seealso name="OnPlayerLeaveRaceCheckpoint"/>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="DisablePlayerCheckpoint"/>
+/// <seealso name="IsPlayerInCheckpoint"/>
+/// <seealso name="SetPlayerRaceCheckpoint"/>
+/// <seealso name="DisablePlayerRaceCheckpoint"/>
+/// <seealso name="IsPlayerInRaceCheckpoint"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerEnterRaceCheckpoint(playerid);
+
+/// <summary>This callback is called when a player leaves the race checkpoint.</summary>
+/// <param name="playerid">The ID of the player that left the race checkpoint</param>
+/// <seealso name="OnPlayerEnterCheckpoint"/>
+/// <seealso name="OnPlayerLeaveCheckpoint"/>
+/// <seealso name="OnPlayerEnterRaceCheckpoint"/>
+/// <seealso name="SetPlayerCheckpoint"/>
+/// <seealso name="DisablePlayerCheckpoint"/>
+/// <seealso name="IsPlayerInCheckpoint"/>
+/// <seealso name="SetPlayerRaceCheckpoint"/>
+/// <seealso name="DisablePlayerRaceCheckpoint"/>
+/// <seealso name="IsPlayerInRaceCheckpoint"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerLeaveRaceCheckpoint(playerid);
+
+/// <summary>This callback is called when a command is sent through the server console, remote RCON, or via the in-game "/rcon command".</summary>
+/// <param name="cmd">A string containing the command that was typed, as well as any passed parameters</param>
+/// <seealso name="IsPlayerAdmin"/>
+/// <seealso name="OnRconLoginAttempt"/>
+/// <remarks>You will need to include this callback in a loaded filterscript for it to work in the gamemode!</remarks>
+/// <remarks>"/rcon" is not included in "cmd" when a player types a command. </remarks>
+/// <remarks>If you use the <a href="#print">print</a> function here, it will send a message to the player who typed the command in-game as well as the log.</remarks>
+/// <remarks>This callback is not called when the player is not logged in as RCON admin. </remarks>
+/// <remarks>When the player is not logged in as RCON admin and uses <b>/rcon login</b>, this callback will not be called and <a href="#OnRconLoginAttempt">OnRconLoginAttempt</a> is called instead. However, when the player is logged in as RCON admin, the use of this command will call this callback. </remarks>
+/// <returns>
+///   <b><c>0</c></b> if the command was not processed, it will be passed to another script or <b><c>1</c></b> if the command was processed, will not be passed to other scripts.<p/>
+///   It is always called first in filterscripts so returning <b><c>1</c></b> there blocks gamemode from seeing it.
+/// </returns>
 forward OnRconCommand(cmd[]);
+
+/// <summary>Called when a player attempts to spawn via class selection either by pressing SHIFT or clicking the 'Spawn' button.</summary>
+/// <param name="playerid">The ID of the player that requested to spawn</param>
+/// <seealso name="OnPlayerSpawn"/>
+/// <seealso name="OnPlayerRequestClass"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>To prevent players from spawning with certain classes, the last viewed class must be saved in a variable in <a href="#OnPlayerRequestClass">OnPlayerRequestClass</a>.</remarks>
+/// <returns>
+///   Returning <b><c>0</c></b> in this callback will prevent the player from spawning.<p/>
+///   It is always called first in filterscripts so returning <b><c>0</c></b> there also blocks other scripts from seeing it.
+/// </returns>
 forward OnPlayerRequestSpawn(playerid);
+
+/// <summary>This callback is called when an object is moved after <a href="#MoveObject">MoveObject</a> (when it stops moving).</summary>
+/// <param name="objectid">The ID of the object that was moved</param>
+/// <seealso name="MoveObject"/>
+/// <seealso name="IsObjectMoving"/>
+/// <seealso name="StopObject"/>
+/// <seealso name="OnPlayerObjectMoved"/>
+/// <remarks><a href="#SetObjectPos">SetObjectPos</a> does not work when used in this callback. To fix it, recreate the object.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnObjectMoved(objectid);
+
+/// <summary>This callback is called when a player object is moved after <a href="#MovePlayerObject">MovePlayerObject</a> (when it stops moving).</summary>
+/// <param name="playerid">The playerid the object is assigned to</param>
+/// <param name="objectid">The ID of the player object that was moved</param>
+/// <seealso name="OnObjectMoved"/>
+/// <seealso name="MovePlayerObject"/>
+/// <seealso name="IsPlayerObjectMoving"/>
+/// <seealso name="StopPlayerObject"/>
+/// <remarks>This callback can also be called for NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerObjectMoved(playerid, objectid);
+
+/// <summary>Called when a player picks up a pickup created with <a href="#CreatePickup">CreatePickup</a>.</summary>
+/// <param name="playerid">The ID of the player that picked up the pickup</param>
+/// <param name="pickupid">The ID of the pickup, returned by CreatePickup</param>
+/// <seealso name="CreatePickup"/>
+/// <seealso name="DestroyPickup"/>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in gamemode.
+/// </returns>
 forward OnPlayerPickUpPickup(playerid, pickupid);
+
+/// <summary>This callback is called when a vehicle is modded.</summary>
+/// <param name="playerid">The ID of the driver of the vehicle</param>
+/// <param name="vehicleid">The ID of the vehicle which is modded</param>
+/// <param name="componentid">The ID of the component which was added to the vehicle</param>
+/// <seealso name="AddVehicleComponent"/>
+/// <seealso name="OnEnterExitModShop"/>
+/// <seealso name="OnVehiclePaintjob"/>
+/// <seealso name="OnVehicleRespray"/>
+/// <remarks>This callback is NOT called by <a href="#AddVehicleComponent">AddVehicleComponent</a>.</remarks>
+/// <returns>
+///   Return <b><c>0</c></b> to desync the mod (or an invalid mod) from propagating and / or crashing players.<p/>
+///   It is always called first in gamemode so returning <b><c>0</c></b> there also blocks other filterscripts from seeing it.
+/// </returns>
 forward OnVehicleMod(playerid, vehicleid, componentid);
+
+/// <summary>This callback is called when a player enters or exits a mod shop.</summary>
+/// <param name="playerid">The ID of the player that entered or exited the modshop</param>
+/// <param name="enterexit"><b><c>1</c></b> if the player entered or <b><c>0</c></b> if they exited</param>
+/// <param name="interiorid">The interior ID of the modshop that the player is entering (or 0 if exiting)</param>
+/// <seealso name="OnVehicleMod"/>
+/// <seealso name="OnVehicleRespray"/>
+/// <seealso name="OnVehiclePaintjob"/>
+/// <seealso name="AddVehicleComponent"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>Players collide when they get into the same mod shop.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnEnterExitModShop(playerid, enterexit, interiorid);
+
+/// <summary>Called when a player previews a vehicle paintjob inside a mod shop. Watch out, this callback is not called when the player buys the paintjob.</summary>
+/// <param name="playerid">The ID of the player that changed the paintjob of their vehicle</param>
+/// <param name="vehicleid">The ID of the vehicle that had its paintjob changed</param>
+/// <param name="paintjobid">The ID of the new paintjob</param>
+/// <seealso name="ChangeVehiclePaintjob"/>
+/// <seealso name="ChangeVehicleColor"/>
+/// <seealso name="OnVehicleRespray"/>
+/// <seealso name="OnVehicleMod"/>
+/// <remarks>This callback is not called by <a href="#ChangeVehiclePaintjob">ChangeVehiclePaintjob</a>.</remarks>
+/// <returns>
+///   This callback does not handle returns. Returning <b><c>0</c></b> won't deny the paintjob change.<p/>
+///   It is always called first in gamemode so returning <b><c>0</c></b> there blocks other filterscripts from seeing it.
+/// </returns>
 forward OnVehiclePaintjob(playerid, vehicleid, paintjobid);
+
+/// <summary>This callback is called when a player exits a mod shop, even if the colors weren't changed. Watch out, the name is ambiguous, Pay 'n' Spray shops don't call this callback.</summary>
+/// <param name="playerid">The ID of the player that is driving the vehicle</param>
+/// <param name="vehicleid">The ID of the vehicle that was resprayed</param>
+/// <param name="color1">The color that the vehicle's primary color was changed to</param>
+/// <param name="color2">The color that the vehicle's secondary color was changed to</param>
+/// <seealso name="ChangeVehicleColor"/>
+/// <seealso name="ChangeVehiclePaintjob"/>
+/// <seealso name="OnVehiclePaintjob"/>
+/// <seealso name="OnVehicleMod"/>
+/// <seealso name="OnEnterExitModShop"/>
+/// <remarks>Previewing a component inside a mod shop might call this callback.</remarks>
+/// <remarks>This callback is not called by <a href="#ChangeVehicleColor">ChangeVehicleColor</a>.</remarks>
+/// <returns>
+///   Returning <b><c>0</c></b> in this callback will deny the colour change. Returning <b><c>1</c></b> will allow it. This can be used to prevent hackers from changing vehicle colours using cheats.<p/>
+///   It is always called first in gamemode so returning <b><c>0</c></b> there also blocks other filterscripts from seeing it.
+/// </returns>
 forward OnVehicleRespray(playerid, vehicleid, color1, color2);
+
+/// <summary>This callback is called when a vehicle element such as doors, tires, panels, or lights change their damage status.</summary>
+/// <param name="vehicleid">The ID of the vehicle that was changed its damage status</param>
+/// <param name="playerid">The ID of the player who synced the change in the damage status (who had the car damaged or repaired)</param>
+/// <seealso name="GetVehicleDamageStatus"/>
+/// <seealso name="UpdateVehicleDamageStatus"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This does not include vehicle health changes</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>0</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in filterscripts.<p/>
+/// </returns>
 forward OnVehicleDamageStatusUpdate(vehicleid, playerid);
+
+/// <summary>This callback is called when a player's client updates/syncs the position of a vehicle they're not driving. This can happen outside of the vehicle or when the player is a passenger of a vehicle that has no driver.</summary>
+/// <param name="vehicleid">The ID of the vehicle that's position was updated</param>
+/// <param name="playerid">The ID of the player that sent a vehicle position sync update</param>
+/// <param name="passenger_seat">The ID of the seat if the player is a passenger. 0=not in vehicle, 1=front passenger, 2=backleft 3=backright 4+ is for coach/bus etc. with many passenger seats</param>
+/// <param name="new_x">The new X coordinate of the vehicle. This parameter was added in <b>0.3z</b>. Leave it out if using an earlier version</param>
+/// <param name="new_y">The new Y coordinate of the vehicle. This parameter was added in <b>0.3z</b>. Leave it out if using an earlier version</param>
+/// <param name="new_z">The new Z coordinate of the vehicle. This parameter was added in <b>0.3z</b>. Leave it out if using an earlier version</param>
+/// <param name="vel_x">The new X velocity of the vehicle. This parameter was added in <b>0.3z R4</b>. Leave it out if using an earlier version</param>
+/// <param name="vel_y">The new Y velocity of the vehicle. This parameter was added in <b>0.3z R4</b>. Leave it out if using an earlier version</param>
+/// <param name="vel_z">The new Z velocity of the vehicle. This parameter was added in <b>0.3z R4</b>. Leave it out if using an earlier version</param>
+/// <seealso name="OnTrailerUpdate"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3c R3</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback is called very frequently per second per unoccupied vehicle. You should refrain from implementing intensive calculations or intensive file writing/reading operations in this callback.</remarks>
+/// <remarks><a href="#GetVehiclePos">GetVehiclePos</a> will return the old coordinates of the vehicle before this update.</remarks>
+/// <returns>
+///   Returning <b><c>0</c></b> in this callback will stop the vehicle's position being synced to other players. Update is still sent to the updating player. Useful for combating vehicle teleport hacks.<p/>
+///   It is always called first in filterscripts so returning <b><c>0</c></b> there also blocks other scripts from seeing it.
+/// </returns>
 forward OnUnoccupiedVehicleUpdate(vehicleid, playerid, passenger_seat, Float:new_x, Float:new_y, Float:new_z, Float:vel_x, Float:vel_y, Float:vel_z);
+
+/// <summary>This callback is called when a player selects an item from a menu (<a href="#ShowMenuForPlayer">ShowMenuForPlayer</a>).</summary>
+/// <param name="playerid">The ID of the player that selected a menu item</param>
+/// <param name="row">The ID of the row that was selected. The first row is ID <b><c>0</c></b></param>
+/// <seealso name="OnPlayerExitedMenu"/>
+/// <seealso name="OnDialogResponse"/>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="DestroyMenu"/>
+/// <seealso name="AddMenuItem"/>
+/// <seealso name="ShowMenuForPlayer"/>
+/// <seealso name="HideMenuForPlayer"/>
+/// <remarks>The menu ID is not passed to this callback. <a href="#GetPlayerMenu">GetPlayerMenu</a> must be used to determine which menu the player selected an item on.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in gamemode.
+/// </returns>
 forward OnPlayerSelectedMenuRow(playerid, row);
+
+/// <summary>Called when a player exits a menu.</summary>
+/// <param name="playerid">The ID of the player that exited the menu</param>
+/// <seealso name="OnPlayerSelectedMenuRow"/>
+/// <seealso name="CreateMenu"/>
+/// <seealso name="DestroyMenu"/>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in gamemode.
+/// </returns>
 forward OnPlayerExitedMenu(playerid);
+
+/// <summary>Called when a player changes interior. Can be triggered by SetPlayerInterior or when a player enter/exits a building.</summary>
+/// <param name="playerid">The playerid who changed interior</param>
+/// <param name="newinteriorid">The interior the player is now in</param>
+/// <param name="oldinteriorid">The interior the player was in before</param>
+/// <seealso name="SetPlayerInterior"/>
+/// <seealso name="GetPlayerInterior"/>
+/// <seealso name="LinkVehicleToInterior"/>
+/// <seealso name="OnPlayerStateChange"/>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in gamemode.
+/// </returns>
 forward OnPlayerInteriorChange(playerid, newinteriorid, oldinteriorid);
+
+/// <summary>This callback is called when the state of any supported key is changed (pressed/released). Directional keys do not trigger OnPlayerKeyStateChange (up/down/left/right).</summary>
+/// <param name="playerid">The ID of the player that pressed or released a key</param>
+/// <param name="newkeys">A map (bitmask) of the keys currently held - see <a href="http://wiki.sa-mp.com/wiki/Keys">here</a></param>
+/// <param name="oldkeys">A map (bitmask) of the keys held prior to the current change - see <a href="http://wiki.sa-mp.com/wiki/Keys">here</a></param>
+/// <seealso name="GetPlayerKeys"/>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>
+///   Useful macros:<p/>
+///   <code>
+///     // HOLDING(keys)<p/>
+///     #define HOLDING(%0) ((newkeys &amp; (%0)) == (%0))<p/>
+///     <p/>
+///     // PRESSED(keys)<p/>
+///     #define PRESSED(%0) (((newkeys &amp; (%0)) == (%0)) &amp;&amp; ((oldkeys &amp; (%0)) != (%0)))<p/>
+///     <p/>
+///     // PRESSING(keyVariable, keys)<p/>
+///     #define PRESSING(%0,%1) (%0 &amp; (%1))<p/>
+///     <p/>
+///     // RELEASED(keys)<p/>
+///     #define RELEASED(%0) (((newkeys &amp; (%0)) != (%0)) &amp;&amp; ((oldkeys &amp; (%0)) == (%0)))<p/>
+///   </code>
+/// </remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in gamemode.
+/// </returns>
 forward OnPlayerKeyStateChange(playerid, newkeys, oldkeys);
+
+/// <summary>This callback is called when someone attempts to log in to RCON in-game; successful or not.</summary>
+/// <param name="ip">The IP of the player that tried to log in to RCON</param>
+/// <param name="password">The password used to login with</param>
+/// <param name="success"><b><c>0</c></b> if the password was incorrect or <b><c>1</c></b> if it was correct</param>
+/// <seealso name="OnRconCommand"/>
+/// <seealso name="IsPlayerAdmin"/>
+/// <seealso name="SendRconCommand"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback is only called when /rcon login is used in-game. </remarks>
+/// <remarks>This callback is only called when the player is not yet logged in. When the player is logged in, <a href="#OnRconCommand">OnRconCommand</a> is called instead.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnRconLoginAttempt( ip[], password[], success );
+
+/// <summary>This callback is called every time a client/player updates the server with their status. It is often used to create custom callbacks for client updates that aren't actively tracked by the server, such as health or armor updates or players switching weapons.</summary>
+/// <param name="playerid">ID of the player sending an update packet</param>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>This callback is called, on average, 30 times per second, per player; only use it when you know what it's meant for (or more importantly what it's NOT meant for). </remarks>
+/// <remarks>The frequency with which this callback is called for each player varies, depending on what the player is doing. Driving or shooting will trigger a lot more updates than idling. </remarks>
+/// <returns>
+///   <b><c>0</c></b> - Update from this player will not be replicated to other clients.<p/>
+///   <b><c>1</c></b> - Indicates that this update can be processed normally and sent to other players.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerUpdate(playerid);
+
+/// <summary>This callback is called when a player is streamed by some other player's client.</summary>
+/// <param name="playerid">The ID of the player who has been streamed</param>
+/// <param name="forplayerid">The ID of the player that streamed the other player in</param>
+/// <seealso name="OnPlayerStreamOut"/>
+/// <seealso name="OnActorStreamIn"/>
+/// <seealso name="OnVehicleStreamIn"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerStreamIn(playerid, forplayerid);
+
+/// <summary>This callback is called when a player is streamed out from some other player's client.</summary>
+/// <param name="playerid">The player who has been destreamed</param>
+/// <param name="forplayerid">The player who has destreamed the other player</param>
+/// <seealso name="OnPlayerStreamIn"/>
+/// <seealso name="OnActorStreamOut"/>
+/// <seealso name="OnVehicleStreamOut"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerStreamOut(playerid, forplayerid);
+
+/// <summary>Called when a vehicle is streamed to a player's client.</summary>
+/// <param name="vehicleid">The ID of the vehicle that streamed in for the player</param>
+/// <param name="forplayerid">The ID of the player who the vehicle streamed in for</param>
+/// <seealso name="OnVehicleStreamOut"/>
+/// <seealso name="OnPlayerStreamIn"/>
+/// <seealso name="OnPlayerStreamOut"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnVehicleStreamIn(vehicleid, forplayerid);
+
+/// <summary>This callback is called when a vehicle is streamed out for a player's client (it's so far away that they can't see it).</summary>
+/// <param name="vehicleid">The ID of the vehicle that streamed out</param>
+/// <param name="forplayerid">The ID of the player who is no longer streaming the vehicle</param>
+/// <seealso name="OnVehicleStreamIn"/>
+/// <seealso name="OnPlayerStreamIn"/>
+/// <seealso name="OnPlayerStreamOut"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <returns>
+///   This callback does not handle returns.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnVehicleStreamOut(vehicleid, forplayerid);
+
+/// <summary>This callback is called when an actor is streamed in by a player's client.</summary>
+/// <param name="actorid">The ID of the actor that has been streamed in for the player</param>
+/// <param name="forplayerid">The ID of the player that streamed the actor in</param>
+/// <seealso name="OnActorStreamOut"/>
+/// <seealso name="OnPlayerStreamIn"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>It is always called first in filterscripts.</remarks>
+/// <returns>This callback does not handle returns.</returns>
 forward OnActorStreamIn(actorid, forplayerid);
+
+/// <summary>This callback is called when an actor is streamed out by a player's client.</summary>
+/// <param name="actorid">The ID of the actor that has been streamed out for the player</param>
+/// <param name="forplayerid">The ID of the player that streamed the actor out</param>
+/// <seealso name="OnActorStreamIn"/>
+/// <seealso name="OnPlayerStreamOut"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>It is always called first in filterscripts.</remarks>
+/// <returns>This callback does not handle returns.</returns>
 forward OnActorStreamOut(actorid, forplayerid);
+
+/// <summary>This callback is called when a player responds to a dialog shown using <a href="#ShowPlayerDialog">ShowPlayerDialog</a> by either clicking a button, pressing ENTER/ESC or double-clicking a list item (if using a list style dialog).</summary>
+/// <param name="playerid">The ID of the player that responded to the dialog</param>
+/// <param name="dialogid">The ID of the dialog the player responded to, assigned in ShowPlayerDialog</param>
+/// <param name="response"><b><c>1</c></b> for left button and <b><c>0</c></b> for right button (if only one button shown, always <b><c>1</c></b>)</param>
+/// <param name="listitem">The ID of the list item selected by the player (starts at <b><c>0</c></b>) (only if using a list style dialog)</param>
+/// <param name="inputtext">The text entered into the input box by the player or the selected list item text</param>
+/// <seealso name="ShowPlayerDialog"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>A player's dialog doesn't hide when the gamemode restarts, causing the server to print <c>"Warning: PlayerDialogResponse PlayerId: 0 dialog ID doesn't match last sent dialog ID"</c> if a player responded to this dialog after restart.</remarks>
+/// <remarks>Parameters can contain different values, based on dialog's <a href="http://wiki.sa-mp.com/wiki/Dialog_Styles">style</a>.</remarks>
+/// <returns>
+///   Returning <b><c>0</c></b> in this callback will pass the dialog to another script in case no matching code were found in your gamemode's callback.<p/>
+///   It is always called first in filterscripts so returning <b><c>1</c></b> there blocks other filterscripts from seeing it.
+/// </returns>
 forward OnDialogResponse(playerid, dialogid, response, listitem, inputtext[]);
+
+/// <summary>This callback is called when a player takes damage.</summary>
+/// <param name="playerid">The ID of the player that took damage</param>
+/// <param name="issuerid">The ID of the player that caused the damage. <b><c>INVALID_PLAYER_ID</c></b> if self-inflicted</param>
+/// <param name="amount">The amount of damage the player took (health and armour combined)</param>
+/// <param name="weaponid">The ID of the <a href="http://wiki.sa-mp.com/wiki/Weapons">weapon/reason</a> for the damage</param>
+/// <param name="bodypart">The body part that was hit. (NOTE: This parameter was added in <b>0.3z</b>. Leave it out if using an older version!)</param>
+/// <seealso name="OnPlayerGiveDamage"/>
+/// <seealso name="OnPlayerWeaponShot"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
+/// <remarks><a href="#GetPlayerHealth">GetPlayerHealth</a> and <a href="#GetPlayerArmour">GetPlayerArmour</a> will return the old amounts of the player before this callback. </remarks>
+/// <remarks>
+///   The weaponid will return <b><c>37</c></b> (flame thrower) from any fire sources (e.g. molotov, <b><c>18</c></b>).<p/>
+///   The weaponid will return <b><c>51</c></b> from any weapon that creates an explosion (e.g. RPG, grenade)<p/>
+///   <b>playerid</b> is the only one who can call the callback.<p/>
+///   The amount is always the maximum damage the weaponid can do, even when the health left is less than that maximum damage. So when a player has <b><c>100.0</c></b> health and gets shot with a Desert Eagle which has a damage value of <b><c>46.2</c></b>, it takes 3 shots to kill that player. All 3 shots will show an amount of <b><c>46.2</c></b>, even though when the last shot hits, the player only has <b><c>7.6</c></b> health left.
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b> - Callback will not be called in other filterscripts.<p/>
+///   <b><c>0</c></b> - Allows this callback to be called in other filterscripts.<p/>
+///   It is always called first in filterscripts so returning <b><c>1</c></b> there blocks other filterscripts from seeing it.
+/// </returns>
 forward OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart);
+
+/// <summary>This callback is called when a player gives damage to another player.</summary>
+/// <param name="playerid">The ID of the player that gave damage</param>
+/// <param name="damagedid">The ID of the player that received damage</param>
+/// <param name="amount">The amount of health/armour damagedid has lost (combined)</param>
+/// <param name="weaponid">The <a href="http://wiki.sa-mp.com/wiki/Weapons">reason</a> that caused the damage</param>
+/// <param name="bodypart">The body part that was hit. (NOTE: This parameter was added in <b>0.3z</b>. Leave it out if using an older version!)</param>
+/// <seealso name="OnPlayerTakeDamage"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   Keep in mind this function can be inaccurate in some cases.<p/>
+///   If you want to prevent certain players from damaging eachother, use <a href="#SetPlayerTeam">SetPlayerTeam</a>.<p/>
+///   The weaponid will return <b><c>37</c></b> (flame thrower) from any fire sources (e.g. molotov, 18)<p/>
+///   The weaponid will return <b><c>51</c></b> from any weapon that creates an explosion (e.g. RPG, grenade)<p/>
+///   <b>playerid</b> is the only one who can call the callback.<p/>
+///   The amount is always the maximum damage the weaponid can do, even when the health left is less than that maximum damage. So when a player has <b><c>100.0</c></b> health and gets shot with a Desert Eagle which has a damage value of <b><c>46.2</c></b>, it takes 3 shots to kill that player. All 3 shots will show an amount of <b><c>46.2</c></b>, even though when the last shot hits, the player only has <b><c>7.6</c></b> health left.
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b> - Callback will not be called in other filterscripts.<p/>
+///   <b><c>0</c></b> - Allows this callback to be called in other filterscripts.<p/>
+///   It is always called first in filterscripts so returning <b><c>1</c></b> there blocks other filterscripts from seeing it.
+/// </returns>
 forward OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart);
+
+/// <summary>This callback is called when a player gives damage to an actor.</summary>
+/// <param name="playerid">The ID of the player that gave damage</param>
+/// <param name="damaged_actorid">The ID of the actor that received damage</param>
+/// <param name="amount">The amount of health/armour damaged_actorid has lost</param>
+/// <param name="weaponid">The reason that caused the damage</param>
+/// <param name="bodypart">The body part that was hit</param>
+/// <seealso name="CreateActor"/>
+/// <seealso name="SetActorInvulnerable"/>
+/// <seealso name="SetActorHealth"/>
+/// <seealso name="GetActorHealth"/>
+/// <seealso name="IsActorInvulnerable"/>
+/// <seealso name="IsValidActor"/>
+/// <seealso name="OnActorStreamOut"/>
+/// <seealso name="OnPlayerStreamIn"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function does not get called if the actor is set invulnerable (WHICH IS BY DEFAULT). See <a href="#SetActorInvulnerable">SetActorInvulnerable</a>.</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Callback will not be called in other filterscripts.<p/>
+///   <b><c>0</c></b> - Allows this callback to be called in other filterscripts.<p/>
+///   It is always called first in filterscripts so returning <b><c>1</c></b> there blocks other filterscripts from seeing it.
+/// </returns>
 forward OnPlayerGiveDamageActor(playerid, damaged_actorid, Float:amount, weaponid, bodypart);
+
+/// <summary>OnPlayerClickMap is called when a player places a target/waypoint on the pause menu map (by right-clicking).</summary>
+/// <param name="playerid">The ID of the player that placed a target/waypoint</param>
+/// <param name="fX">The X float coordinate where the player clicked</param>
+/// <param name="fY">The Y float coordinate where the player clicked</param>
+/// <param name="fZ">The Z float coordinate where the player clicked (inaccurate - see note below)</param>
+/// <seealso name="SetPlayerPos"/>
+/// <seealso name="SetPlayerPosFindZ"/>
+/// <seealso name="GetPlayerPos"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3d</b> and will not work in earlier versions!</remarks>
+/// <remarks>The Z value returned will be <b><c>0</c></b> (invalid) if it is far away from the player; use the <a href="http://forum.sa-mp.com/showthread.php?t=275492">MapAndreas plugin</a> to get a more accurate Z coordinate.</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>0</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in gamemode.
+/// </returns>
 forward OnPlayerClickMap(playerid, Float:fX, Float:fY, Float:fZ);
+
+/// <summary>This callback is called when a player clicks on a textdraw or cancels the select mode with the Escape key.</summary>
+/// <param name="playerid">The ID of the player that clicked on the textdraw</param>
+/// <param name="clickedid">The ID of the clicked textdraw. <b><c>INVALID_TEXT_DRAW</c></b> if selection was cancelled</param>
+/// <seealso name="OnPlayerClickPlayerTextDraw"/>
+/// <seealso name="OnPlayerClickPlayer"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>The clickable area is defined by <a href="#TextDrawTextSize">TextDrawTextSize</a>. The x and y parameters passed to that function must not be zero or negative. </remarks>
+/// <remarks>Do not use <a href="#CancelSelectTextDraw">CancelSelectTextDraw</a> unconditionally within this callback. This results in an infinite loop. </remarks>
+/// <returns>
+///   Returning <b><c>1</c></b> in this callback will prevent it being called in other scripts. This should be used to signal that the textdraw on which they clicked was 'found' and no further processing is needed. You should return <b><c>0</c></b> if the textdraw on which they clicked wasn't found, just like in <a href="#OnPlayerCommandText">OnPlayerCommandText</a>.<p/>
+///   It is always called first in filterscripts so returning <b><c>1</c></b> there also blocks other scripts from seeing it.
+/// </returns>
 forward OnPlayerClickTextDraw(playerid, Text:clickedid);
+
+/// <summary>This callback is called when a player clicks on a player-textdraw. It is not called when player cancels the select mode (ESC) - however, <a href="#OnPlayerClickTextDraw">OnPlayerClickTextDraw</a> is.</summary>
+/// <param name="playerid">The ID of the player that selected a textdraw</param>
+/// <param name="playertextid">The ID of the player-textdraw that the player selected</param>
+/// <seealso name="PlayerTextDrawSetSelectable"/>
+/// <seealso name="OnPlayerClickTextDraw"/>
+/// <seealso name="OnPlayerClickPlayer"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>When a player presses ESC to cancel selecting a textdraw, <a href="#OnPlayerClickTextDraw">OnPlayerClickTextDraw</a> is called with a textdraw ID of <b><c>INVALID_TEXT_DRAW</c></b>. <a href="#OnPlayerClickPlayerTextDraw">OnPlayerClickPlayerTextDraw</a> won't be called also.</remarks>
+/// <returns>
+///   Returning <b><c>1</c></b> in this callback will prevent it being called in other scripts. This should be used to signal that the textdraw on which they clicked was 'found' and no further processing is needed. You should return <b><c>0</c></b> if the textdraw on which they clicked wasn't found, just like in <a href="#OnPlayerCommandText">OnPlayerCommandText</a>.<p/>
+///   It is always called first in filterscripts so returning <b><c>1</c></b> there also blocks other scripts from seeing it.
+/// </returns>
 forward OnPlayerClickPlayerTextDraw(playerid, PlayerText:playertextid);
+
+/// <summary>This callback is called when an IP address attempts a connection to the server. To block incoming connections, use <a href="#BlockIpAddress">BlockIpAddress</a>.</summary>
+/// <param name="playerid">The ID of the player attempting to connect</param>
+/// <param name="ip_address">The IP address of the player attempting to connect</param>
+/// <param name="port">The port of the attempted connection</param>
+/// <seealso name="OnPlayerConnect"/>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <seealso name="OnPlayerFinishedDownloading"/>
+/// <seealso name="BlockIpAddress"/>
+/// <seealso name="UnBlockIpAddress"/>
+/// <remarks> 	This callback was added in <b>SA-MP 0.3z R2-2</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>0</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnIncomingConnection(playerid, ip_address[], port);
+
+/// <summary>This callback is called when a player sent a trailer update.</summary>
+/// <param name="playerid">The ID of the player who sent a trailer update</param>
+/// <param name="vehicleid">The Trailer being updated</param>
+/// <seealso name="OnUnoccupiedVehicleUpdate"/>
+/// <seealso name="GetVehicleTrailer"/>
+/// <seealso name="IsTrailerAttachedToVehicle"/>
+/// <seealso name="AttachTrailerToVehicle"/>
+/// <seealso name="DetachTrailerFromVehicle"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3z R4</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback is called very frequently per second per trailer. You should refrain from implementing intensive calculations or intensive file writing/reading operations in this callback. </remarks>
+/// <returns>
+///   <b><c>0</c></b> - Cancels any trailer updates from being sent to other players. Update is still sent to the updating player.<p/>
+///   <b><c>1</c></b> - Processes the trailer update as normal and synchronizes it between all players.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnTrailerUpdate(playerid, vehicleid);
+
+/// <summary>This callback is called when a vehicle's siren is toggled.</summary>
+/// <param name="playerid">The ID of the player that toggled the siren (driver)</param>
+/// <param name="vehicleid">The ID of the vehicle of which the siren was toggled for</param>
+/// <param name="newstate"><b><c>0</c></b> if siren was turned off, <b><c>1</c></b> if siren was turned on</param>
+/// <seealso name="GetVehicleParamsSirenState"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback can also be called by NPC.</remarks>
+/// <remarks>This callback is only called when a vehicle's siren is toggled on or off, NOT when the alternate siren is in use (holding horn).</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Will prevent gamemode from receiving this callback.<p/>
+///   <b><c>0</c></b> - Indicates that this callback will be passed to the gamemode.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnVehicleSirenStateChange(playerid, vehicleid, newstate);
+
+/// <summary>This callback is called when a player finishes downloading custom models. For more information on how to add custom models to your server, see <a href="http://forum.sa-mp.com/showthread.php?t=644105">the release thread</a> and <a href="http://forum.sa-mp.com/showthread.php?t=644123">this tutorial</a>.</summary>
+/// <param name="playerid">The ID of the player that finished downloading custom models</param>
+/// <param name="virtualworld">The ID of the virtual world the player finished downloading custom models for</param>
+/// <seealso name="OnPlayerConnect"/>
+/// <seealso name="OnPlayerDisconnect"/>
+/// <seealso name="OnIncomingConnection"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3DL</b> and will not work in earlier versions!</remarks>
+/// <remarks>This callback is called every time a player changes virtual worlds, even if there are no custom models present in that world.</remarks>
+/// <returns>This callback does not handle returns.</returns>
 forward OnPlayerFinishedDownloading(playerid, virtualworld);
 forward OnPlayerRequestDownload(playerid, type, crc);
 
 #define CLICK_SOURCE_SCOREBOARD		0
+
+/// <summary>Called when a player double-clicks on a player on the scoreboard.</summary>
+/// <param name="playerid">The ID of the player that clicked on a player on the scoreboard</param>
+/// <param name="clickedplayerid">The ID of the player that was clicked on</param>
+/// <param name="source">The source of the player's click</param>
+/// <seealso name="OnPlayerClickTextDraw"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>There is currently only one <paramref name="source"/> (<b><c>0 - CLICK_SOURCE_SCOREBOARD</c></b>). The existence of this argument suggests that more sources may be supported in the future.</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Will prevent other filterscripts from receiving this callback.<p/>
+///   <b><c>0</c></b> - Indicates that this callback will be passed to the next filterscript.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerClickPlayer(playerid, clickedplayerid, source);
 
 #define EDIT_RESPONSE_CANCEL		0
 #define EDIT_RESPONSE_FINAL			1
 #define EDIT_RESPONSE_UPDATE		2
 
+
+/// <summary>This callback is called when a player finishes editing an object (<a href="#EditObject">EditObject</a>/<a href="#EditPlayerObject">EditPlayerObject</a>).</summary>
+/// <param name="playerid">The ID of the player that edited an object</param>
+/// <param name="playerobject"><b><c>0</c></b> if it is a global object or <b><c>1</c></b> if it is a playerobject</param>
+/// <param name="objectid">The ID of the edited object</param>
+/// <param name="response">The type of response</param>
+/// <param name="fX">The X offset for the object that was edited</param>
+/// <param name="fY">The Y offset for the object that was edited</param>
+/// <param name="fZ">The Z offset for the object that was edited</param>
+/// <param name="fRotX">The X rotation for the object that was edited</param>
+/// <param name="fRotY">The Y rotation for the object that was edited</param>
+/// <param name="fRotZ">The Z rotation for the object that was edited</param>
+/// <seealso name="EditObject"/>
+/// <seealso name="CreateObject"/>
+/// <seealso name="DestroyObject"/>
+/// <seealso name="MoveObject"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>When using <b><c>EDIT_RESPONSE_UPDATE</c></b> be aware that this callback will not be called when releasing an edit in progress resulting in the last update of <b><c>EDIT_RESPONSE_UPDATE</c></b> being out of sync of the objects current position.</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Will prevent other scripts from receiving this callback.<p/>
+///   <b><c>0</c></b> - Indicates that this callback will be passed to the next script.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerEditObject( playerid, playerobject, objectid, response, 
 Float:fX, Float:fY, Float:fZ, Float:fRotX, Float:fRotY, Float:fRotZ );
 
+
+/// <summary>This callback is called when a player ends attached object edition mode.</summary>
+/// <param name="playerid">The ID of the player that ended edition mode</param>
+/// <param name="response"><b><c>0</c></b> if they cancelled (ESC) or <b><c>1</c></b> if they clicked the save icon</param>
+/// <param name="index">The index of the attached object</param>
+/// <param name="modelid">The model of the attached object that was edited</param>
+/// <param name="boneid">The bone of the attached object that was edited</param>
+/// <param name="fOffsetX">The X offset for the attached object that was edited</param>
+/// <param name="fOffsetY">The Y offset for the attached object that was edited</param>
+/// <param name="fOffsetZ">The Z offset for the attached object that was edited</param>
+/// <param name="fRotX">The X rotation for the attached object that was edited</param>
+/// <param name="fRotY">The Y rotation for the attached object that was edited</param>
+/// <param name="fRotZ">The Z rotation for the attached object that was edited</param>
+/// <param name="fScaleX">The X scale for the attached object that was edited</param>
+/// <param name="fScaleY">The Y scale for the attached object that was edited</param>
+/// <param name="fScaleZ">The Z scale for the attached object that was edited</param>
+/// <seealso name="EditAttachedObject"/>
+/// <seealso name="SetPlayerAttachedObject"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>Editions should be discarded if response was <b><c>0</c></b> (cancelled). This must be done by storing the offsets etc. in an array BEFORE using <a href="#EditAttachedObject">EditAttachedObject</a>.</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Will prevent other scripts from receiving this callback.<p/>
+///   <b><c>0</c></b> - Indicates that this callback will be passed to the next script.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerEditAttachedObject( playerid, response, index, modelid, boneid,
 Float:fOffsetX, Float:fOffsetY, Float:fOffsetZ,
 Float:fRotX, Float:fRotY, Float:fRotZ,
@@ -427,6 +2961,22 @@ Float:fScaleX, Float:fScaleY, Float:fScaleZ );
 #define SELECT_OBJECT_GLOBAL_OBJECT	1
 #define SELECT_OBJECT_PLAYER_OBJECT 2
 
+
+/// <summary>This callback is called when a player selects an object after <a href="#SelectObject">SelectObject</a> has been used.</summary>
+/// <param name="playerid">The ID of the player that selected an object</param>
+/// <param name="type">The type of selection</param>
+/// <param name="objectid">The ID of the selected object</param>
+/// <param name="modelid">The model ID of the selected object</param>
+/// <param name="fX">The X position of the selected object</param>
+/// <param name="fY">The Y position of the selected object</param>
+/// <param name="fZ">The Z position of the selected object</param>
+/// <seealso name="SelectObject"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b> - Will prevent other scripts from receiving this callback.<p/>
+///   <b><c>0</c></b> - Indicates that this callback will be passed to the next script.<p/>
+///   It is always called first in filterscripts.
+/// </returns>
 forward OnPlayerSelectObject(playerid, type, objectid, modelid, Float:fX, Float:fY, Float:fZ);
 
 #define BULLET_HIT_TYPE_NONE			0
@@ -435,6 +2985,47 @@ forward OnPlayerSelectObject(playerid, type, objectid, modelid, Float:fX, Float:
 #define BULLET_HIT_TYPE_OBJECT			3
 #define BULLET_HIT_TYPE_PLAYER_OBJECT	4
 
+
+/// <summary>This callback is called when a player fires a shot from a weapon. Only bullet weapons are supported. Only <b>passenger</b> drive-by is supported (not driver drive-by, and not sea sparrow / hunter shots).</summary>
+/// <param name="playerid">The ID of the player that shot a weapon</param>
+/// <param name="weaponid">The ID of the <a href="http://wiki.sa-mp.com/wiki/Weapons">weapon</a> shot by the player</param>
+/// <param name="hittype">The type of thing the shot hit (none, player, vehicle, or (player)object)</param>
+/// <param name="hitid">The ID of the player, vehicle or object that was hit</param>
+/// <param name="fX">The X coordinate that the shot hit</param>
+/// <param name="fY">The Y coordinate that the shot hit</param>
+/// <param name="fZ">The Z coordinate that the shot hit</param>
+/// <seealso name="OnPlayerGiveDamage"/>
+/// <seealso name="GetPlayerLastShotVectors"/>
+/// <remarks>This callback was added in <b>SA-MP 0.3z</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///     <li><b><c>BULLET_HIT_TYPE_NONE(0)</c></b></li>
+///     <li><b><c>BULLET_HIT_TYPE_PLAYER(1)</c></b></li>
+///     <li><b><c>BULLET_HIT_TYPE_VEHICLE(2)</c></b></li>
+///     <li><b><c>BULLET_HIT_TYPE_OBJECT(3)</c></b></li>
+///     <li><b><c>BULLET_HIT_TYPE_PLAYER_OBJECT(4)</c></b></li>
+/// </remarks>
+/// <remarks><b><c>BULLET_HIT_TYPE_PLAYER</c></b> is also called for NPCs. Actors are ignored by this callback and detects as <b><c>BULLET_HIT_TYPE_NONE</c></b>.</remarks>
+/// <remarks>This callback is only called when lag compensation is <b>enabled</b>. </remarks>
+/// <remarks>
+///   If hittype is:<p/>
+///   <ul>
+///     <li>- <b><c>BULLET_HIT_TYPE_NONE</c></b>: the fX, fY and fZ parameters are normal coordinates, will give 0.0 for coordinates if nothing was hit (e.g. far object that the bullet can't reach);</li>
+///     <li>- Others: the fX, fY and fZ are offsets relative to the hitid.</li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   Isn't called if you fired in vehicle as driver or if you are looking behind with the aim enabled (shooting in air).<p/>
+///   It is called as <b><c>BULLET_HIT_TYPE_VEHICLE</c></b> with the correct hitid (the hit player's vehicleid) if you are shooting a player which is in a vehicle. It won't be called as <b><c>BULLET_HIT_TYPE_PLAYER</c></b> at all.<p/>
+///   <b>Partially fixed in SA-MP 0.3.7:</b> If fake weapon data is sent by a malicious user, other player clients may freeze or crash. To combat this, check if the reported weaponid can actually fire bullets.
+/// </remarks>
+/// <remarks>
+/// </remarks>
+/// <remarks><a href="#GetPlayerLastShotVectors">GetPlayerLastShotVectors</a> can be used in this callback for more detailed bullet vector information.</remarks>
+/// <returns>
+///   <b><c>0</c></b> - Prevent the bullet from causing damage.<p/>
+///   <b><c>1</c></b> - Allow the bullet to cause damage.<p/>
+///   It is always called first in filterscripts so returning <b><c>0</c></b> there also blocks other scripts from seeing it.
+/// </returns>
 forward OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, Float:fX, Float:fY, Float:fZ);
 
 // --------------------------------------------------

--- a/a_sampdb.inc
+++ b/a_sampdb.inc
@@ -9,21 +9,121 @@
 #define _sampdb_included
 #pragma library sampdb
 
+/// <summary>This function is used to open a connection to a SQLite database, which is inside the <b><c>/scriptfiles</c></b> folder.</summary>
+/// <param name="name">File name of the database</param>
+/// <remarks>Return type for this function has changed since version <b>0.3.7 R2</b>.</remarks>
+/// <remarks>
+///   It will create a new SQLite database, if there is no SQLite database with the same file name available.<p/>
+///   <b>Close</b> your database connection with <a href="#db_close">db_close</a>!
+/// </remarks>
+/// <returns>Returns index (starting at <b><c>1</c></b>) of the database connection .</returns>
 native DB:db_open(name[]);
+
+/// <summary>Closes an SQLite database that was opened with <a href="#db_open">db_open</a>.</summary>
+/// <param name="db">The handle of the database connection to close (returned by <a href="#db_open">db_open</a>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. May mean that the database handle specified is not open.
+/// </returns>
 native db_close(DB:db);
+
+/// <summary>This function is used to execute an SQL query on an opened SQLite database.</summary>
+/// <param name="db">The database handle to query</param>
+/// <param name="query">The query to execute</param>
+/// <remarks>Return type for this function has changed since version <b>0.3.7 R2</b>.</remarks>
+/// <remarks><b>Always</b> free the result by using <a href="#db_free_result">db_free_result</a>!</remarks>
+/// <returns>The query result index (<b>starting at 1</b>).</returns>
 native DBResult:db_query(DB:db, query[]);
+
+/// <summary>Frees result memory allocated from <a href="#db_query">db_query</a>.</summary>
+/// <param name="dbresult">The result to free</param>
+/// <returns>If <b><c>DBResult:dbhandle</c></b> is a valid handle, it returns <b><c>1</c></b>, otherwise <b><c>0</c></b> if <b><c>DBResult:dbhandle</c></b> is a <b><c>NULL</c></b> reference.</returns>
 native db_free_result(DBResult:dbresult);
+
+/// <summary>Returns the number of rows from a <a href="#db_query">db_query</a>.</summary>
+/// <param name="dbresult">The result of <a href="#db_query">db_query</a></param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>The number of rows in the result.</returns>
 native db_num_rows(DBResult:dbresult);
+
+/// <summary>Moves to the next row of the result allocated from <a href="#db_query">db_query</a>.</summary>
+/// <param name="dbresult">The result of <a href="#db_query">db_query</a></param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>Returns <b><c>1</c></b> on success, otherwise <b><c>0</c></b> if <b><c>DBResult:dbresult</c></b> is a <b><c>NULL</c></b> reference or the last row is reached.</returns>
 native db_next_row(DBResult:dbresult);
+
+/// <summary>Get the number of fields in a result.</summary>
+/// <param name="dbresult">The result of <a href="#db_query">db_query</a></param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>The number of fields in the result.</returns>
 native db_num_fields(DBResult:dbresult);
+
+/// <summary>Returns the name of a field at a particular index.</summary>
+/// <param name="dbresult">The result to get the data from; returned by <a href="#db_query">db_query</a></param>
+/// <param name="field">The index of the field to get the name of</param>
+/// <param name="result">The result</param>
+/// <param name="maxlength">The max length of the field</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>Returns <b><c>1</c></b>, if the function was successful, otherwise <b><c>0</c></b> if <b><c>DBResult:dbresult</c></b> is a <b><c>NULL</c></b> reference or the column index not available.</returns>
 native db_field_name(DBResult:dbresult, field, result[], maxlength);
+
+/// <summary>Get the content of a field from <a href="#db_query">db_query</a>.</summary>
+/// <param name="dbresult">The result to get the data from</param>
+/// <param name="field">The field to get the data from</param>
+/// <param name="result">The result</param>
+/// <param name="maxlength">The max length of the field</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>Returns <b><c>1</c></b> if successful, otherwise <b><c>0</c></b> if <b><c>DBResult:dbresult</c></b> is a <b><c>NULL</c></b> reference or the column index not available.</returns>
 native db_get_field(DBResult:dbresult, field, result[], maxlength);
+
+/// <summary>Get the content of a field as an integer from <a href="#db_query">db_query</a>.</summary>
+/// <param name="result">The result to get the data from</param>
+/// <param name="field">The field to get the data from (optional=<b><c>0</c></b>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>Retrieved value as integer (number).</returns>
 native db_get_field_int(DBResult:result, field = 0);
+
+/// <summary>Get the content of a field as a float from db_query.</summary>
+/// <param name="result">The result to get the data from</param>
+/// <param name="field">The field to get the data from (optional=<b><c>0</c></b>)</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>Retrieved value as floating point number.</returns>
 native Float:db_get_field_float(DBResult:result, field = 0);
+
+/// <summary>Get the contents of field with specified name.</summary>
+/// <param name="dbresult">The result to get the data from</param>
+/// <param name="field">The fieldname to get the data from</param>
+/// <param name="result">The result</param>
+/// <param name="maxlength">The max length of the field</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>Returns <b><c>1</c></b> if successful, otherwise <b><c>0</c></b> if <b><c>DBResult:dbresult</c></b> is a <b><c>NULL</c></b> reference or the column index not available.</returns>
 native db_get_field_assoc(DBResult:dbresult, const field[], result[], maxlength);
+
+/// <summary>Get the contents of field as an integer with specified name.</summary>
+/// <param name="result">The result to get the data from</param>
+/// <param name="field">The fieldname to get the data from</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>Retrieved value as integer (number).</returns>
 native db_get_field_assoc_int(DBResult:result, const field[]);
+
+/// <summary>Get the contents of field as a float with specified name.</summary>
+/// <param name="result">The result to get the data from</param>
+/// <param name="field">The fieldname to get the data from</param>
+/// <remarks>Using an <b>invalid handle</b> will crash your server! Get a <b>valid handle</b> by using <a href="#db_open">db_open</a>. But it's protected against <b><c>NULL</c></b> references</remarks>
+/// <returns>Retrieved value as floating point number.</returns>
 native Float:db_get_field_assoc_float(DBResult:result, const field[]);
+
+/// <summary>Get memory handle for an SQLite database that was opened with <a href="#db_open">db_open</a>.</summary>
+/// <param name="db">The index of the database connection (returned by <a href="#db_open">db_open</a>)</param>
+/// <remarks>This function was added in <b>SA-MP 0.3.7 R1</b> and will not work in earlier versions!</remarks>
+/// <returns>Returns the memory handle for a specified database.</returns>
 native db_get_mem_handle(DB:db);
+
+/// <summary>Get <b>memory handle</b> for an SQLite query that was executed with <a href="#db_query">db_query</a>.</summary>
+/// <param name="result">The index of the query (returned by <a href="#db_query">db_query</a>)</param>
+/// <remarks>This function was added in <b>SA-MP 0.3.7 R1</b> and will not work in earlier versions!</remarks>
+/// <returns>Returns the memory handle for a specified query.</returns>
 native db_get_result_mem_handle(DBResult:result);
 
 native db_debug_openfiles();

--- a/a_vehicles.inc
+++ b/a_vehicles.inc
@@ -30,45 +30,654 @@
 #define VEHICLE_PARAMS_ON		1
 
 // Vehicle
+
+/// <summary>Creates a vehicle in the world. Can be used in place of <a href="#AddStaticVehicleEx">AddStaticVehicleEx</a> at any time in the script.</summary>
+/// <param name="vehicletype">The <a href="http://wiki.sa-mp.com/wiki/Vehicle_Models">model</a> for the vehicle</param>
+/// <param name="x">The X coordinate for the vehicle</param>
+/// <param name="y">The Y coordinate for the vehicle</param>
+/// <param name="z">The Z coordinate for the vehicle</param>
+/// <param name="rotation">The facing angle for the vehicle</param>
+/// <param name="color1">The primary <a href="http://wiki.sa-mp.com/wiki/Color_ID">color ID</a></param>
+/// <param name="color2">The secondary <a href="http://wiki.sa-mp.com/wiki/Color_ID">color ID</a></param>
+/// <param name="respawn_delay">The delay until the car is respawned without a driver in <b>seconds</b>. Using <b><c>-1</c></b> will prevent the vehicle from respawning</param>
+/// <param name="addsiren"><b>Added in 0.3.7; will not work in earlier versions</b>. Enables the vehicle to have a siren, providing the vehicle has a horn (optional=<b><c>0</c></b>)</param>
+/// <seealso name="DestroyVehicle"/>
+/// <seealso name="AddStaticVehicle"/>
+/// <seealso name="AddStaticVehicleEx"/>
+/// <seealso name="GetVehicleParamsSirenState"/>
+/// <seealso name="OnVehicleSpawn"/>
+/// <seealso name="OnVehicleSirenStateChange"/>
+/// <remarks>Trains can only be added with AddStaticVehicle and AddStaticVehicleEx.</remarks>
+/// <returns>
+///   The vehicle ID of the vehicle created (<b><c>1</c></b> to <b><c>MAX_VEHICLES</c></b>).<p/>
+///   <b><c>INVALID_VEHICLE_ID (65535)</c></b> if vehicle was not created (vehicle limit reached or invalid vehicle model ID passed).
+/// </returns>
 native CreateVehicle(vehicletype, Float:x, Float:y, Float:z, Float:rotation, color1, color2, respawn_delay, addsiren=0);
+
+/// <summary>Destroy a vehicle. It will disappear instantly.</summary>
+/// <param name="vehicleid">The ID of the vehicle to destroy</param>
+/// <seealso name="CreateVehicle"/>
+/// <seealso name="RemovePlayerFromVehicle"/>
+/// <seealso name="SetVehicleToRespawn"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle does not exist.
+/// </returns>
 native DestroyVehicle(vehicleid);
+
+/// <summary>Checks if a vehicle is streamed in for a player. Only nearby vehicles are streamed in (visible) for a player.</summary>
+/// <param name="vehicleid">The ID of the vehicle to check</param>
+/// <param name="forplayerid">The ID of the player to check</param>
+/// <seealso name="IsPlayerStreamedIn"/>
+/// <seealso name="OnVehicleStreamIn"/>
+/// <seealso name="OnVehicleStreamOut"/>
+/// <seealso name="OnPlayerStreamIn"/>
+/// <seealso name="OnPlayerStreamOut"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>0</c></b>: Vehicle is not streamed in for the player, or the function failed to execute (player and/or vehicle do not exist).<p/>
+///   <b><c>1</c></b>: Vehicle is streamed in for the player.
+/// </returns>
 native IsVehicleStreamedIn(vehicleid, forplayerid);
+
+/// <summary>Gets the position of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the position of</param>
+/// <param name="x">A float variable in which to store the X coordinate, passed by reference</param>
+/// <param name="y">A float variable in which to store the Y coordinate, passed by reference</param>
+/// <param name="z">A float variable in which to store the Z coordinate, passed by reference</param>
+/// <seealso name="GetVehicleDistanceFromPoint"/>
+/// <seealso name="SetVehiclePos"/>
+/// <seealso name="GetVehicleZAngle"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle specified does not exist.
+/// </returns>
 native GetVehiclePos(vehicleid, &Float:x, &Float:y, &Float:z);
+
+/// <summary>Set a vehicle's position.</summary>
+/// <param name="vehicleid">Vehicle ID that you want set new position</param>
+/// <param name="x">The X coordinate to position the vehicle at</param>
+/// <param name="y">The Y coordinate to position the vehicle at</param>
+/// <param name="z">The Z coordinate to position the vehicle at</param>
+/// <seealso name="SetPlayerPos"/>
+/// <seealso name="GetVehiclePos"/>
+/// <seealso name="SetVehicleZAngle"/>
+/// <remarks>An empty vehicle will not fall after being teleported into the air.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle specified does not exist.
+/// </returns>
 native SetVehiclePos(vehicleid, Float:x, Float:y, Float:z);
+
+/// <summary>Get the rotation of a vehicle on the Z axis (yaw).</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the Z angle of</param>
+/// <param name="z_angle">A float variable in which to store the Z rotation, passed by reference</param>
+/// <seealso name="GetVehicleRotationQuat"/>
+/// <seealso name="GetVehicleRotation"/>
+/// <seealso name="SetVehicleZAngle"/>
+/// <seealso name="GetVehiclePos"/>
+/// <seealso name="GetPlayerFacingAngle"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the vehicle does not exist.
+/// </returns>
 native GetVehicleZAngle(vehicleid, &Float:z_angle);
+
+/// <summary>Returns a vehicle's rotation on all axes as a quaternion.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the rotation of</param>
+/// <param name="w">A float variable in which to store the first quaternion angle, passed by reference</param>
+/// <param name="x">A float variable in which to store the second quaternion angle, passed by reference</param>
+/// <param name="y">A float variable in which to store the third quaternion angle, passed by reference</param>
+/// <param name="z">A float variable in which to store the fourth quaternion angle, passed by reference</param>
+/// <seealso name="GetVehicleZAngle"/>
+/// <remarks>This function was added in <b>SA-MP 0.3b</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>To euler:</b><p/>
+///   <code>
+///     //GetVehicleRotation Created by IllidanS4<p/>
+///     stock GetVehicleRotation(vehicleid,&amp;Float:rx,&amp;Float:ry,&amp;Float:rz){<p/>
+///     &#9;new Float:qw,Float:qx,Float:qy,Float:qz;<p/>
+///     &#9;GetVehicleRotationQuat(vehicleid,qw,qx,qy,qz);<p/>
+///     &#9;rx = asin(2*qy*qz-2*qx*qw);<p/>
+///     &#9;ry = -atan2(qx*qz+qy*qw,0.5-qx*qx-qy*qy);<p/>
+///     &#9;rz = -atan2(qx*qy+qz*qw,0.5-qx*qx-qz*qz);<p/>
+///     }
+///   </code>
+/// </remarks>
+/// <remarks>There is no 'set' variation of this function; you can not SET a vehicle's rotation (apart from the <a href="#SetVehicleZAngle">Z angle</a>) </remarks>
+/// <remarks>This function may return incorrect values for unoccupied vehicles. The reason is that the third row of the vehicle's internal rotation matrix gets corrupted if it gets updated while unoccupied. </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the vehicle specified does not exist.
+/// </returns>
 native GetVehicleRotationQuat(vehicleid, &Float:w, &Float:x, &Float:y, &Float:z);
+
+/// <summary>This function can be used to calculate the distance (as a float) between a vehicle and another map coordinate. This can be useful to detect how far a vehicle away is from a location.</summary>
+/// <param name="vehicleid">The ID of the vehicle to calculate the distance for</param>
+/// <param name="X">The X map coordinate</param>
+/// <param name="Y">The Y map coordinate</param>
+/// <param name="Z">The Z map coordinate</param>
+/// <seealso name="GetPlayerDistanceFromPoint"/>
+/// <seealso name="GetVehiclePos"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c R3</b> and will not work in earlier versions!</remarks>
+/// <returns>A float containing the distance from the point specified in the coordinates.</returns>
 native Float:GetVehicleDistanceFromPoint(vehicleid, Float:X, Float:Y, Float:Z);
+
+/// <summary>Set the Z rotation (yaw) of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the rotation of</param>
+/// <param name="z_angle">The Z angle to set</param>
+/// <seealso name="GetVehicleZAngle"/>
+/// <seealso name="SetVehiclePos"/>
+/// <remarks>A vehicle's X and Y (pitch and roll) rotation will be reset when this function is used. The X and Y rotations can not be set.</remarks>
+/// <remarks>This function does not work on unoccupied vehicles.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle specified does not exist.
+/// </returns>
 native SetVehicleZAngle(vehicleid, Float:z_angle);
+
+/// <summary>Set the parameters of a vehicle for a player.</summary>
+/// <param name="vehicle">The ID of the vehicle to set the parameters of</param>
+/// <param name="playerid">The ID of the player to set the vehicle's parameters for</param>
+/// <param name="objective"><b><c>0</c></b> to disable the objective or <b><c>1</c></b> to show it. This is a bobbing yellow arrow above the vehicle</param>
+/// <param name="doorslocked"><b><c>0</c></b> to unlock the doors or <b><c>1</c></b> to lock them</param>
+/// <seealso name="SetVehicleParamsEx"/>
+/// <remarks>Vehicles must be respawned for the 'objective' to be removed. This can be circumvented somewhat using Get/SetVehicleParamsEx which do not require the vehicle to be respawned. It is worth noting however that the object will be disabled on a global scale, and this is only useful if only one player has the vehicle as an objective.</remarks>
+/// <remarks>Since <b>0.3a</b> you will have to reapply this function when <a href="#OnVehicleStreamIn">OnVehicleStreamIn</a> is called.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The player and/or vehicle specified do not exist.
+/// </returns>
 native SetVehicleParamsForPlayer(vehicleid,playerid,objective,doorslocked);
+
+/// <summary>Use this function before any player connects (<a href="#OnGameModeInit">OnGameModeInit</a>) to tell all clients that the script will control vehicle engines and lights. This prevents the game automatically turning the engine on/off when players enter/exit vehicles and headlights automatically coming on when it is dark.</summary>
+/// <seealso name="SetVehicleParamsEx"/>
+/// <seealso name="GetVehicleParamsEx"/>
+/// <seealso name="SetVehicleParamsForPlayer"/>
+/// <remarks>This Function was added in <b>SA-MP 0.3c</b> and will not work in earlier versions!</remarks>
+/// <remarks>Is it not possible to reverse this function after it has been used. You must either use it or not use it.</remarks>
+/// <returns>This function always returns <b><c>1</c></b>. It cannot fail to execute.</returns>
 native ManualVehicleEngineAndLights();
+
+/// <summary>Sets a vehicle's parameters for all players.</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the parameters of</param>
+/// <param name="engine">Engine status. <b><c>0</c></b> - Off, <b><c>1</c></b> - On</param>
+/// <param name="lights">Light status. <b><c>0</c></b> - Off, <b><c>1</c></b> - On</param>
+/// <param name="alarm">Vehicle alarm status. If on, the alarm starts. <b><c>0</c></b> - Off, <b><c>1</c></b> - On</param>
+/// <param name="doors">Door lock status. <b><c>0</c></b> - Unlocked, <b><c>1</c></b> - Locked</param>
+/// <param name="bonnet">Bonnet (hood) status. <b><c>0</c></b> - Closed, <b><c>1</c></b> - Open</param>
+/// <param name="boot">Boot/trunk status. <b><c>0</c></b> - Closed, <b><c>1</c></b> - Open</param>
+/// <param name="objective">Toggle the objective arrow above the vehicle. <b><c>0</c></b> - Off, <b><c>1</c></b> - On</param>
+/// <seealso name="GetVehicleParamsEx"/>
+/// <seealso name="SetVehicleParamsForPlayer"/>
+/// <seealso name="UpdateVehicleDamageStatus"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c</b> and will not work in earlier versions! </remarks>
+/// <remarks>The alarm will not reset when finished, you'll need to reset it by yourself with this function. </remarks>
+/// <remarks>Lights also operate during the day (Only when <a href="#ManualVehicleEngineAndLights">ManualVehicleEngineAndLights</a> is enabled). </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the vehicle does not exist.
+/// </returns>
 native SetVehicleParamsEx(vehicleid, engine, lights, alarm, doors, bonnet, boot, objective);
+
+/// <summary>Gets a vehicle's parameters.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the parameters from</param>
+/// <param name="engine">Get the engine status. If <b><c>1</c></b>, the engine is running.</param>
+/// <param name="lights">Get the vehicle's lights' state. If <b><c>1</c></b> the lights are on</param>
+/// <param name="alarm">Get the vehicle's alarm state. If <b><c>1</c></b> the alarm is (or was) sounding</param>
+/// <param name="doors">Get the lock status of the doors. If <b><c>1</c></b> the doors are locked</param>
+/// <param name="bonnet">Get the bonnet/hood status. If <b><c>1</c></b>, it's open</param>
+/// <param name="boot">Get the boot/trunk status. <b><c>1</c></b> means it is open</param>
+/// <param name="objective">Get the objective status. <b><c>1</c></b> means the objective is on</param>
+/// <seealso name="SetVehicleParamsEx"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c</b> and will not work in earlier versions!</remarks>
+/// <remarks>If a parameter is unset (SetVehicleParamsEx not used beforehand) the value will be <b><c>-1</c></b> ('unset').</remarks>
 native GetVehicleParamsEx(vehicleid, &engine, &lights, &alarm, &doors, &bonnet, &boot, &objective);
+
+/// <summary>Returns a vehicle's siren state (on/off).</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the siren state of</param>
+/// <seealso name="OnVehicleSirenStateChange"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c R3</b> and will not work in earlier versions!</remarks>
+/// <returns><b><c>-1</c></b> if unset (off), <b><c>0</c></b> if off, <b><c>1</c></b> if on</returns>
 native GetVehicleParamsSirenState(vehicleid);
+
+/// <summary>Allows you to open and close the doors of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the door state of</param>
+/// <param name="driver">The state of the driver's door. <b><c>1</c></b> to open, <b><c>0</c></b> to close</param>
+/// <param name="passenger">The state of the passenger door. <b><c>1</c></b> to open, <b><c>0</c></b> to close</param>
+/// <param name="backleft">The state of the rear left door (if available). <b><c>1</c></b> to open, <b><c>0</c></b> to close</param>
+/// <param name="backright">The state of the rear right door (if available). <b><c>1</c></b> to open, <b><c>0</c></b> to close</param>
+/// <seealso name="GetVehicleParamsCarDoors"/>
+/// <seealso name="SetVehicleParamsCarWindows"/>
+/// <seealso name="GetVehicleParamsCarWindows"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks><b><c>1</c></b> is open, <b><c>0</c></b> is closed</remarks>
 native SetVehicleParamsCarDoors(vehicleid, driver, passenger, backleft, backright);
+
+/// <summary>Allows you to retrieve the current state of a vehicle's doors.</summary>
+/// <param name="vehicleid">The ID of the vehicle</param>
+/// <param name="driver">The integer to save the state of the driver's door to</param>
+/// <param name="passenger">The integer to save the state of the passenger's door to</param>
+/// <param name="backleft">The integer to save the state of the rear left door to (if available)</param>
+/// <param name="backright">The integer to save the state of the rear right door to (if available)</param>
+/// <seealso name="SetVehicleParamsCarDoors"/>
+/// <seealso name="SetVehicleParamsCarWindows"/>
+/// <seealso name="GetVehicleParamsCarWindows"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>The values returned in each variable are as follows: <b><c>-1</c></b> if not set, <b><c>0</c></b> if closed, <b><c>1</c></b> if open.</remarks>
 native GetVehicleParamsCarDoors(vehicleid, &driver, &passenger, &backleft, &backright);
+
+/// <summary>Allows you to open and close the windows of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the window state of</param>
+/// <param name="driver">The state of the driver's window. <b><c>0</c></b> to open, <b><c>1</c></b> to close</param>
+/// <param name="passenger">The state of the passenger window. <b><c>0</c></b> to open, <b><c>1</c></b> to close</param>
+/// <param name="backleft">The state of the rear left window (if available). <b><c>0</c></b> to open, <b><c>1</c></b> to close</param>
+/// <param name="backright">The state of the rear right window (if available). <b><c>0</c></b> to open, <b><c>1</c></b> to close</param>
+/// <seealso name="SetVehicleParamsCarDoors"/>
+/// <seealso name="GetVehicleParamsCarDoors"/>
+/// <seealso name="GetVehicleParamsCarWindows"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
 native SetVehicleParamsCarWindows(vehicleid, driver, passenger, backleft, backright);
+
+/// <summary>Allows you to retrieve the current state of a vehicle's windows.</summary>
+/// <param name="vehicleid">The ID of the vehicle</param>
+/// <param name="driver">The integer to save the state of the drivers window to</param>
+/// <param name="passenger">The integer to save the state of the passengers window to</param>
+/// <param name="backleft">The integer to save the state of the rear left window to (if available)</param>
+/// <param name="backright">The integer to save the state of the rear right window to (if available)</param>
+/// <seealso name="SetVehicleParamsCarWindows"/>
+/// <seealso name="GetVehicleParamsCarDoors"/>
+/// <seealso name="SetVehicleParamsCarDoors"/>
+/// <remarks>This function was added in <b>SA-MP 0.3.7</b> and will not work in earlier versions!</remarks>
+/// <remarks>The values returned in each variable are as follows: <b><c>-1</c></b> if not set, <b><c>0</c></b> if closed, <b><c>1</c></b> if open.</remarks>
+/// <returns>The vehicle's windows state is stored in the specified variables.</returns>
 native GetVehicleParamsCarWindows(vehicleid, &driver, &passenger, &backleft, &backright);
+
+/// <summary>Sets a vehicle back to the position at where it was created.</summary>
+/// <param name="vehicleid">The ID of the vehicle to respawn</param>
+/// <seealso name="CreateVehicle"/>
+/// <seealso name="DestroyVehicle"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle does not exist.
+/// </returns>
 native SetVehicleToRespawn(vehicleid);
+
+/// <summary>Links a vehicle to an interior. Vehicles can only be seen by players in the same interior (<a href="#SetPlayerInterior">SetPlayerInterior</a>).</summary>
+/// <param name="vehicleid">The ID of the vehicle to link to an interior</param>
+/// <param name="interiorid">The <a href="http://wiki.sa-mp.com/wiki/InteriorIDs">Interior ID</a> to link it to</param>
+/// <seealso name="SetVehicleVirtualWorld"/>
+/// <seealso name="SetPlayerInterior"/>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the vehicle does not exist.<p/>
+/// </returns>
 native LinkVehicleToInterior(vehicleid, interiorid);
+
+/// <summary>Adds a 'component' (often referred to as a 'mod' (modification)) to a vehicle. Valid components can be found <a href="http://wiki.sa-mp.com/wiki/Car_Component_ID">here</a>.</summary>
+/// <param name="vehicleid">The ID of the vehicle to add the component to. Not to be confused with <a href="http://wiki.sa-mp.com/wiki/Confuse_modelid">modelid</a></param>
+/// <param name="componentid">The <a href="http://wiki.sa-mp.com/wiki/Car_Component_ID">ID of the component</a> to add to the vehicle</param>
+/// <returns>
+///   <ul>
+///     <li><b><c>0</c></b> - The component was not added because the vehicle does not exist.</li>
+///     <li><b><c>1</c></b> - The component was successfully added to the vehicle.</li>
+///   </ul>
+/// </returns>
+/// <remarks>Using an invalid <a href="http://wiki.sa-mp.com/wiki/Car_Component_ID">component ID</a> crashes the player's game. There are no internal checks for this.</remarks>
+/// <seealso name="RemoveVehicleComponent"/>
+/// <seealso name="GetVehicleComponentInSlot"/>
+/// <seealso name="GetVehicleComponentType"/>
+/// <seealso name="OnVehicleMod"/>
+/// <seealso name="OnEnterExitModShop"/>
 native AddVehicleComponent(vehicleid, componentid);
+
+/// <summary>Remove a component from a vehicle.</summary>
+/// <param name="vehicleid">ID of the vehicle</param>
+/// <param name="componentid">ID of the <a href="http://wiki.sa-mp.com/wiki/Car_Component_ID">component</a> to remove</param>
+/// <seealso name="AddVehicleComponent"/>
+/// <seealso name="GetVehicleComponentInSlot"/>
+/// <seealso name="GetVehicleComponentType"/>
+/// <seealso name="OnVehicleMod"/>
+/// <seealso name="OnEnterExitModShop"/>
 native RemoveVehicleComponent(vehicleid, componentid);
+
+/// <summary>Change a vehicle's primary and secondary colors.</summary>
+/// <param name="vehicleid">The ID of the vehicle to change the colors of</param>
+/// <param name="color1">The new vehicle's primary <a href="http://wiki.sa-mp.com/wiki/Color_ID">Color ID</a></param>
+/// <param name="color2">The new vehicle's secondary <a href="http://wiki.sa-mp.com/wiki/Color_ID">Color ID</a></param>
+/// <seealso name="ChangeVehiclePaintjob"/>
+/// <seealso name="OnVehicleRespray"/>
+/// <remarks>Some vehicles have only a primary color and some can not have the color changed at all. A few (cement, squallo) have 4 colors, of which 2 can not be changed in SA:MP</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully. The vehicle's color was successfully changed.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle does not exist.
+/// </returns>
 native ChangeVehicleColor(vehicleid, color1, color2);
+
+/// <summary>Change a vehicle's paintjob (for plain colors see <a href="#ChangeVehicleColor">ChangeVehicleColor</a>).</summary>
+/// <param name="vehicleid">The ID of the vehicle to change the paintjob of</param>
+/// <param name="paintjobid">The ID of the Paintjob to apply. Use <b><c>3</c></b> to remove a paintjob</param>
+/// <seealso name="ChangeVehicleColor"/>
+/// <seealso name="OnVehiclePaintjob"/>
+/// <remarks>
+///   <b>Known Bugs:</b><p/>
+///   This function calls <a href="#OnVehicleRespray">OnVehicleRespray</a>.<p/>
+///   Vehicles change their color to white anymore when a paintjob is removed.
+/// </remarks>
+/// <returns>This function always returns <b><c>1</c></b> (success), even if the vehicle passed is not created.</returns>
 native ChangeVehiclePaintjob(vehicleid, paintjobid);
+
+
+/// <summary>Set a vehicle's health. When a vehicle's health decreases the engine will produce smoke, and finally fire when it decreases to less than 250 (25%).</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the health of</param>
+/// <param name="health">The health, given as a float value</param>
+/// <seealso name="GetVehicleHealth"/>
+/// <seealso name="RepairVehicle"/>
+/// <seealso name="SetPlayerHealth"/>
+/// <seealso name="OnVehicleDeath"/>
+/// <remarks>Full vehicle health is <b><c>1000</c></b>, however higher values are possible and increase the health of the vehicle.</remarks>
+/// <remarks>
+///   <b>Health:</b><p/>
+///   <ul>
+///     <li>&gt; 650 - undamaged</li>
+///     <li>650-550 - white Smoke</li>
+///     <li>550-390 - grey Smoke</li>
+///     <li>390-250 - black Smoke</li>
+///     <li>&lt; 250 - on fire (will explode seconds later)</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the vehicle does not exist.
+/// </returns>
 native SetVehicleHealth(vehicleid, Float:health);
+
+/// <summary>Get the health of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the health of</param>
+/// <param name="health">A float variable in which to store the vehicle's health, passed by reference</param>
+/// <seealso name="SetVehicleHealth"/>
+/// <seealso name="GetPlayerHealth"/>
+/// <seealso name="GetPlayerArmour"/>
+/// <remarks>Full vehicle health is <b><c>1000</c></b>, however higher values are possible and increase the health of the vehicle.</remarks>
+/// <remarks>
+///   <b>Health:</b><p/>
+///   <ul>
+///     <li>&gt; 650 - undamaged</li>
+///     <li>650-550 - white Smoke</li>
+///     <li>550-390 - grey Smoke</li>
+///     <li>390-250 - black Smoke</li>
+///     <li>&lt; 250 - on fire (will explode seconds later)</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b> - success.<p/>
+///   <b><c>0</c></b> - failure (invalid vehicle ID).<p/>
+/// </returns>
 native GetVehicleHealth(vehicleid, &Float:health);
+
+/// <summary>Attach a vehicle to another vehicle as a trailer.</summary>
+/// <param name="trailerid">The ID of the vehicle that will be pulled</param>
+/// <param name="vehicleid">The ID of the vehicle that will pull the trailer</param>
+/// <seealso name="DetachTrailerFromVehicle"/>
+/// <seealso name="IsTrailerAttachedToVehicle"/>
+/// <seealso name="GetVehicleTrailer"/>
+/// <remarks>This will only work if both vehicles are streamed in for a player (check <a href="#IsVehicleStreamedIn">IsVehicleStreamedIn</a>).</remarks>
+/// <returns>This function always returns <b><c>1</c></b>, even if neither of the vehicle IDs passed are valid.</returns>
 native AttachTrailerToVehicle(trailerid, vehicleid);
+
+/// <summary>Detach the connection between a vehicle and its trailer, if any.</summary>
+/// <param name="vehicleid">ID of the pulling vehicle</param>
+/// <seealso name="AttachTrailerToVehicle"/>
+/// <seealso name="IsTrailerAttachedToVehicle"/>
+/// <seealso name="GetVehicleTrailer"/>
 native DetachTrailerFromVehicle(vehicleid);
+
+/// <summary>Checks if a vehicle has a trailer attached to it. Use <a href="#GetVehicleTrailer">GetVehicleTrailer</a> to get the vehicle ID of the trailer (if any).</summary>
+/// <param name="vehicleid">The ID of the vehicle to check for trailers</param>
+/// <seealso name="GetVehicleTrailer"/>
+/// <seealso name="AttachTrailerToVehicle"/>
+/// <seealso name="DetachTrailerFromVehicle"/>
+/// <returns><b><c>1</c></b> if the vehicle has a trailer attached, <b><c>0</c></b> if not.</returns>
 native IsTrailerAttachedToVehicle(vehicleid);
+
+/// <summary>Get the ID of the trailer attached to a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the trailer of</param>
+/// <seealso name="AttachTrailerToVehicle"/>
+/// <seealso name="DetachTrailerFromVehicle"/>
+/// <seealso name="IsTrailerAttachedToVehicle"/>
+/// <returns>The vehicle ID of the trailer or <b><c>0</c></b> if no trailer is attached.</returns>
 native GetVehicleTrailer(vehicleid);
+
+/// <summary>Set a vehicle numberplate.</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the number plate of</param>
+/// <param name="numberplate">The text that should be displayed on the number plate</param>
+/// <seealso name="SetVehicleToRespawn"/>
+/// <seealso name="ChangeVehicleColor"/>
+/// <seealso name="ChangeVehiclePaintjob"/>
+/// <remarks>This function was added in <b>SA-MP 0.3c</b> and will not work in earlier versions!</remarks>
+/// <remarks>You can use color embedding on the number plate text.</remarks>
+/// <remarks>
+///   This function has no internal error checking. Do not assign custom number plates to vehicles without plates (boats, planes, etc) as this will result in some unneeded processing time on the client.<p/>
+///   The vehicle must be re-spawned or re-streamed for the changes to take effect.<p/>
+///   There's a limit of 32 characters on each number plate (including embedded colors).<p/>
+///   The text length that can be seen on the number plate is around 9 to 10 characters, more characters will cause the text to split.<p/>
+///   Some vehicle models has a backward number plate, e.g. Boxville (498) (as an alternative to this vehicle you can use vehicle model ID 609, which is a duplicated Boxville (aka Boxburg), but with a regular number plate).<p/>
+///   This function only works in versions <b>0.2.1</b>, <b>0.2.2</b>, <b>0.2x</b> and <b>0.3c</b> (and beyond). 
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle does not exist.<p/>
+/// </returns>
 native SetVehicleNumberPlate(vehicleid, numberplate[]);
+
+/// <summary>Gets the <a href="http://wiki.sa-mp.com/wiki/Vehicle_Models">model ID</a> of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the model of</param>
+/// <seealso name="GetPlayerVehicleID"/>
+/// <seealso name="GetVehiclePos"/>
+/// <seealso name="GetVehicleZAngle"/>
+/// <seealso name="GetPlayerVehicleSeat"/>
+/// <returns>The vehicle's <a href="http://wiki.sa-mp.com/wiki/Vehicle_Models">model ID</a>, or <b><c>0</c></b> if the vehicle doesn't exist.</returns>
 native GetVehicleModel(vehicleid);
+
+/// <summary>Retrieves the installed component ID (modshop mod(ification)) on a vehicle in a specific slot.</summary>
+/// <param name="vehicleid">The ID of the vehicle to check for the component</param>
+/// <param name="slot">The component slot to check for components (see below)</param>
+/// <seealso name="AddVehicleComponent"/>
+/// <seealso name="GetVehicleComponentType"/>
+/// <seealso name="OnVehicleMod"/>
+/// <seealso name="OnEnterExitModShop"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Slots:</b><p/>
+///   <c>
+///     CARMODTYPE_SPOILER
+///     CARMODTYPE_HOOD
+///     CARMODTYPE_ROOF
+///     CARMODTYPE_SIDESKIRT
+///     CARMODTYPE_LAMPS
+///     CARMODTYPE_NITRO
+///     CARMODTYPE_EXHAUST
+///     CARMODTYPE_WHEELS
+///     CARMODTYPE_STEREO
+///     CARMODTYPE_HYDRAULICS
+///     CARMODTYPE_FRONT_BUMPER
+///     CARMODTYPE_REAR_BUMPER
+///     CARMODTYPE_VENT_RIGHT
+///     CARMODTYPE_VENT_LEFT
+///   </c>
+/// </remarks>
+/// <remarks>
+///   <b>Known Bugs:</b><p/>
+///   <ul>
+///     <li>Doesn't work for <b><c>CARMODTYPE_STEREO</c></b>.</li>
+///     <li>Both front bull bars and front bumper components are saved in the <b><c>CARMODTYPE_FRONT_BUMPER</c></b> slot. If a vehicle has both of them installed, this function will only return the one which was installed last.</li>
+///     <li>Both rear bull bars and rear bumper components are saved in the <b><c>CARMODTYPE_REAR_BUMPER</c></b> slot. If a vehicle has both of them installed, this function will only return the one which was installed last.</li>
+///     <li>Both left side skirt and right side skirt are saved in the <b><c>CARMODTYPE_SIDESKIRT</c></b> slot. If a vehicle has both of them installed, this function will only return the one which was installed last. </li>
+///   </ul>
+/// </remarks>
+/// <returns>The ID of the component installed in the specified slot. Returns <b><c>0</c></b> if no component in specified vehicle's specified slot, or if vehicle doesn't exist.</returns>
 native GetVehicleComponentInSlot(vehicleid, slot); // There is 1 slot for each CARMODTYPE_*
+
+/// <summary>Find out what type of component a certain ID is.</summary>
+/// <param name="component">The component ID to check</param>
+/// <seealso name="AddVehicleComponent"/>
+/// <seealso name="RemoveVehicleComponent"/>
+/// <seealso name="GetVehicleComponentInSlot"/>
+/// <seealso name="OnVehicleMod"/>
+/// <seealso name="OnEnterExitModShop"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>The component slot ID of the specified component or <b><c>-1</c></b> if the component is invalid.</returns>
 native GetVehicleComponentType(component); // Find CARMODTYPE_* for component id
+
+/// <summary>Fully repairs a vehicle, including visual damage (bumps, dents, scratches, popped tires etc.).</summary>
+/// <param name="vehicleid">The ID of the vehicle to repair</param>
+/// <seealso name="SetVehicleHealth"/>
+/// <seealso name="GetVehicleHealth"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the vehicle specified does not exist.
+/// </returns>
 native RepairVehicle(vehicleid); // Repairs the damage model and resets the health
+
+/// <summary>Get the velocity of a vehicle on the X, Y and Z axes.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the velocity of</param>
+/// <param name="X">A float variable in to which to store the vehicle's X velocity, passed by reference</param>
+/// <param name="Y">A float variable in to which to store the vehicle's Y velocity, passed by reference</param>
+/// <param name="Z">A float variable in to which to store the vehicle's Z velocity, passed by reference</param>
+/// <seealso name="GetPlayerVelocity"/>
+/// <seealso name="SetVehicleVelocity"/>
+/// <seealso name="SetPlayerVelocity"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>Multiply vector with <b><c>250.66667</c></b> for kmph or <b><c>199.416667</c></b> for mph or something...</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the vehicle specified does not exist.<p/>
+/// </returns>
 native GetVehicleVelocity(vehicleid, &Float:X, &Float:Y, &Float:Z);
+
+/// <summary>Sets the X, Y and Z velocity of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the velocity of</param>
+/// <param name="X">The velocity in the X direction</param>
+/// <param name="Y">The velocity in the Y direction </param>
+/// <param name="Z">The velocity in the Z direction</param>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function has no affect on un-occupied vehicles and does not affect trains.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle does not exist.
+/// </returns>
 native SetVehicleVelocity(vehicleid, Float:X, Float:Y, Float:Z);
+
+/// <summary>Sets the angular X, Y and Z velocity of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the velocity of</param>
+/// <param name="X">The amount of velocity in the angular X direction</param>
+/// <param name="Y">The amount of velocity in the angular Y direction </param>
+/// <param name="Z">The amount of velocity in the angular Z direction</param>
+/// <seealso name="SetVehicleVelocity"/>
+/// <seealso name="GetVehicleVelocity"/>
+/// <remarks>This function was added in <b>SA-MP 0.3b</b> and will not work in earlier versions!</remarks>
+/// <remarks>This function has no effect on un-occupied vehicles and does not effect trains.</remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. The vehicle does not exist.
+/// </returns>
 native SetVehicleAngularVelocity(vehicleid, Float:X, Float:Y, Float:Z);
+
+/// <summary>Retrieve the damage statuses of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the damage statuses of</param>
+/// <param name="panels">A variable to store the panel damage data in, passed by reference</param>
+/// <param name="doors">A variable to store the door damage data in, passed by reference</param>
+/// <param name="lights">A variable to store the light damage data in, passed by reference</param>
+/// <param name="tires">A variable to store the tire damage data in, passed by reference</param>
+/// <seealso name="UpdateVehicleDamageStatus"/>
+/// <seealso name="SetVehicleHealth"/>
+/// <seealso name="GetVehicleHealth"/>
+/// <seealso name="RepairVehicle"/>
+/// <seealso name="OnVehicleDamageStatusUpdate"/>
+/// <remarks>This Callback was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Door states:</b><p/>
+///   <ul>
+///     <li><b><c>0x000000FF</c></b> - hood</li>
+///     <li><b><c>0x0000FF00</c></b> - trunk</li>
+///     <li><b><c>0x00FF0000</c></b> - drivers door</li>
+///     <li><b><c>0xFF000000</c></b> - co-drivers door</li>
+///     <li>byte meaning:</li>
+///     <li><b><c>0x1</c></b> - is opened</li>
+///     <li><b><c>0x2</c></b> - is damaged</li>
+///     <li><b><c>0x4</c></b> - is removed</li>
+///     <li>other bytes are unused</li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   <b>Light states:</b><p/>
+///   <ul>
+///     <li><b><c>0x01</c></b> - front left broken</li>
+///     <li><b><c>0x04</c></b> - front right broken</li>
+///     <li><b><c>0x40</c></b> - back both broken</li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   <b>Tire states:</b><p/>
+///   <ul>
+///     <li><b><c>0x1</c></b> - back right popped</li>
+///     <li><b><c>0x2</c></b> - front right popped</li>
+///     <li><b><c>0x4</c></b> - back left popped</li>
+///     <li><b><c>0x8</c></b> - front left popped</li>
+///     <li>only check the right states for bikes</li>
+///   </ul>
+/// </remarks>
+/// <returns>
+///   <b><c>1</c></b>: The function executed successfully.<p/>
+///   <b><c>0</c></b>: The function failed to execute. This means the vehicle specified does not exist.
+/// </returns>
 native GetVehicleDamageStatus(vehicleid, &panels, &doors, &lights, &tires);
+
+/// <summary>Sets the various visual damage statuses of a vehicle, such as popped tires, broken lights and damaged panels.</summary>
+/// <param name="vehicleid">The ID of the vehicle to set the damage of</param>
+/// <param name="panels">A set of bits containing the panel damage status</param>
+/// <param name="doors">A set of bits containing the door damage status</param>
+/// <param name="lights">A set of bits containing the light damage status</param>
+/// <param name="tires">A set of bits containing the tire damage status</param>
+/// <seealso name="SetVehicleHealth"/>
+/// <seealso name="GetVehicleHealth"/>
+/// <seealso name="RepairVehicle"/>
+/// <seealso name="GetVehicleDamageStatus"/>
+/// <seealso name="OnVehicleDamageStatusUpdate"/>
+/// <remarks>This function was added in <b>SA-MP 0.3a</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Door states:</b><p/>
+///   <ul>
+///     <li><b><c>0x000000FF</c></b> - hood</li>
+///     <li><b><c>0x0000FF00</c></b> - trunk</li>
+///     <li><b><c>0x00FF0000</c></b> - drivers door</li>
+///     <li><b><c>0xFF000000</c></b> - co-drivers door</li>
+///     <li>byte meaning:</li>
+///     <li><b><c>0x1</c></b> - is opened</li>
+///     <li><b><c>0x2</c></b> - is damaged</li>
+///     <li><b><c>0x4</c></b> - is removed</li>
+///     <li>other bytes are unused</li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   <b>Light states:</b><p/>
+///   <ul>
+///     <li><b><c>0x01</c></b> - front left broken</li>
+///     <li><b><c>0x04</c></b> - front right broken</li>
+///     <li><b><c>0x40</c></b> - back both broken</li>
+///   </ul>
+/// </remarks>
+/// <remarks>
+///   <b>Tire states:</b><p/>
+///   <ul>
+///     <li><b><c>0x1</c></b> - back right popped</li>
+///     <li><b><c>0x2</c></b> - front right popped</li>
+///     <li><b><c>0x4</c></b> - back left popped</li>
+///     <li><b><c>0x8</c></b> - front left popped</li>
+///     <li>only check the right states for bikes</li>
+///   </ul>
+/// </remarks>
 native UpdateVehicleDamageStatus(vehicleid, panels, doors, lights, tires);
 
 #define VEHICLE_MODEL_INFO_SIZE				1
@@ -81,8 +690,43 @@ native UpdateVehicleDamageStatus(vehicleid, panels, doors, lights, tires);
 #define VEHICLE_MODEL_INFO_FRONT_BUMPER_Z	8
 #define VEHICLE_MODEL_INFO_REAR_BUMPER_Z	9
 
+
+/// <summary>Retrieve information about a specific vehicle model such as the size or position of seats.</summary>
+/// <param name="vehiclemodel">The vehicle <a href="http://wiki.sa-mp.com/wiki/Vehicles:All">model</a> to get info of</param>
+/// <param name="infotype">The type of information to retrieve</param>
+/// <param name="X">A float to store the X value</param>
+/// <param name="Y">A float to store the Y value</param>
+/// <param name="Z">A float to store the Z value</param>
+/// <seealso name="GetVehicleModel"/>
+/// <remarks>This function was added in <b>SA-MP 0.3e</b> and will not work in earlier versions!</remarks>
+/// <remarks>
+///   <b>Information types:</b><p/>
+///   <ul>
+///     <li><b><c>VEHICLE_MODEL_INFO_SIZE</c></b> - vehicle size</li>
+///     <li><b><c>VEHICLE_MODEL_INFO_FRONTSEAT</c></b> - position of the front seat</li>
+///     <li><b><c>VEHICLE_MODEL_INFO_REARSEAT</c></b> - position of the rear seat</li>
+///     <li><b><c>VEHICLE_MODEL_INFO_PETROLCAP</c></b> - position of the fuel cap</li>
+///     <li><b><c>VEHICLE_MODEL_INFO_WHEELSFRONT</c></b> - position of the front wheels</li>
+///     <li><b><c>VEHICLE_MODEL_INFO_WHEELSREAR</c></b> - position of the rear wheels</li>
+///     <li><b><c>VEHICLE_MODEL_INFO_WHEELSMID</c></b> - position of the middle wheels (applies to vehicles with 3 axes)</li>
+///     <li><b><c>VEHICLE_MODEL_INFO_FRONT_BUMPER_Z</c></b> - height of the front bumper</li>
+///     <li><b><c>VEHICLE_MODEL_INFO_REAR_BUMPER_Z </c></b> - height of the rear bumper</li>
+///   </ul>
+/// </remarks>
 native GetVehicleModelInfo(vehiclemodel, infotype, &Float:X, &Float:Y, &Float:Z);
 
 // Virtual Worlds
+
+/// <summary>Sets the 'virtual world' of a vehicle. Players will only be able to see vehicles in their own virtual world.</summary>
+/// <param name="vehicleid">The ID of vehicle to set the virtual world of</param>
+/// <param name="worldid">The ID of the virtual world to put the vehicle in</param>
+/// <seealso name="GetVehicleVirtualWorld"/>
+/// <seealso name="SetPlayerVirtualWorld"/>
 native SetVehicleVirtualWorld(vehicleid, worldid);
+
+/// <summary>Get the virtual world of a vehicle.</summary>
+/// <param name="vehicleid">The ID of the vehicle to get the virtual world of</param>
+/// <seealso name="SetVehicleVirtualWorld"/>
+/// <seealso name="GetPlayerVirtualWorld"/>
+/// <returns>The virtual world that the vehicle is in.</returns>
 native GetVehicleVirtualWorld(vehicleid);


### PR DESCRIPTION
Adds pawndoc to the functions, coming from sa-mp wiki (see basdon/documented-samp-pawn-api).

Notes:
* some doc missing, 0.3.7-DL or NPC functions/callbacks (`GetPlayerCustomSkin` `AddCharModel` `AddSimpleModel` `AddSimpleModelTimed` `FindModelFileNameFromCRC` `FindTextureFileNameFromCRC` `RedirectDownload` `OnPlayerRequestDownload` `NPC:GetPlayerArmedWeapon` `NPC:GetPlayerHealth` `NPC:GetPlayerArmour`)
* ~~`GetPlayerIP`: parameter `name` renamed to `ip`~~ (reverted)
* the documentation also uses `<b>` and `<a>` tags, which will not work with the default XSLT file that comes with pawn. I've left them in there because they are useful if customized XSLT files are used (see [yugecin/pawndocimproved](https://github.com/yugecin/pawndocimproved)), and it will not cause troubles if the default is used.

