### PR TITLE
fix the order of parameters in atan2()

### DIFF
--- a/a_samp.inc
+++ b/a_samp.inc
@@ -338,12 +338,12 @@ native Float:acos(Float:value);
 native Float:atan(Float:value);
 
 /// <summary>Get the multi-valued inversed value of a tangent in radians.</summary>
-/// <param name="x">x size</param>
 /// <param name="y">y size</param>
+/// <param name="x">x size</param>
 /// <seealso name="atan"/>
 /// <seealso name="floattan"/>
 /// <returns>The angle in radians.</returns>
-native Float:atan2(Float:x, Float:y);
+native Float:atan2(Float:y, Float:x);
 
 
 /// <summary>Gets the highest playerid currently in use on the server.</summary>


### PR DESCRIPTION
Parameters `x` and `y` seem to be mixed up. When `atan2` is called with parameters `1.0` and `0.0` respectively (`atan2(1.0, 0.0)`) it returns `90` (`89.999...` actually) which is an angle between the positive X-axis and a ray from `(0.0, 0.0)` to `(0.0, 1.0)` (not to `(1.0, 0.0)`).