### PR TITLE
fix descriptions for inverse trigonometric functions in a_npc

### DIFF
--- a/a_npc.inc
+++ b/a_npc.inc
@@ -108,32 +108,32 @@ native KillTimer(timerid);
 /// <returns>Uptime of the actual server (not the SA-MP server).</returns>
 native GetTickCount();
 
-/// <summary>Get the inversed value of a sine in radians.</summary>
+/// <summary>Get the inversed value of a sine in degrees.</summary>
 /// <param name="value">The sine for which to find the angle for</param>
 /// <seealso name="floatsin"/>
-/// <returns>The angle in radians.</returns>
+/// <returns>The angle in degrees.</returns>
 native Float:asin(Float:value);
 
-/// <summary>Get the inversed value of a cosine in radians.</summary>
+/// <summary>Get the inversed value of a cosine in degrees.</summary>
 /// <param name="value">The cosine for which to find the angle for</param>
 /// <seealso name="floatcos"/>
-/// <returns>The angle in radians.</returns>
+/// <returns>The angle in degrees.</returns>
 native Float:acos(Float:value);
 
-/// <summary>Get the inversed value of a tangent in radians.</summary>
+/// <summary>Get the inversed value of a tangent in degrees.</summary>
 /// <param name="value">The tangent for which to find the angle for</param>
 /// <seealso name="atan2"/>
 /// <seealso name="floattan"/>
-/// <returns>The angle in radians.</returns>
+/// <returns>The angle in degrees.</returns>
 native Float:atan(Float:value);
 
-/// <summary>Get the multi-valued inversed value of a tangent in radians.</summary>
-/// <param name="x">x size</param>
+/// <summary>Get the multi-valued inversed value of a tangent in degrees.</summary>
 /// <param name="y">y size</param>
+/// <param name="x">x size</param>
 /// <seealso name="atan"/>
 /// <seealso name="floattan"/>
-/// <returns>The angle in radians.</returns>
-native Float:atan2(Float:x, Float:y);
+/// <returns>The angle in degrees.</returns>
+native Float:atan2(Float:y, Float:x);
 
 
 /// <summary>This will send a player text by the bot, just like using <a href="#SendPlayerMessageToAll">SendPlayerMessageToAll</a>, but this function is to be used inside the NPC scripts.</summary>


### PR DESCRIPTION
same as PR #13 and #14 but for `a_npc`

(maybe all the common definitions could be in a third file which both `a_samp` and `a_npc` could include if you don't mind deviating from the original structure)