### PR TITLE
Check incompatible include combinations.

### DIFF
--- a/a_npc.inc
+++ b/a_npc.inc
@@ -7,6 +7,9 @@
 #if defined _INC_a_npc
 	#endinput
 #endif
+#if defined _INC_a_samp
+	#error Include `<a_samp>` or `<a_npc>`, not both.
+#endif
 #define _INC_a_npc
 #define _samp_included
 

--- a/a_npc.inc
+++ b/a_npc.inc
@@ -236,6 +236,8 @@ open.mp releases can use `A` as the first digit.
 // Util
 
 #if !defined _console_included
+	#define _console_included
+
 	/// <summary>Prints a string to the server console (not in-game chat) and logs (server_log.txt).</summary>
 	/// <param name="string">The string to print</param>
 	/// <seealso name="printf"/>

--- a/a_samp.inc
+++ b/a_samp.inc
@@ -7,6 +7,9 @@
 #if defined _INC_a_samp
 	#endinput
 #endif
+#if defined _INC_a_npc
+	#error Include `<a_samp>` or `<a_npc>`, not both.
+#endif
 #define _INC_a_samp
 #define _samp_included
 

--- a/a_samp.inc
+++ b/a_samp.inc
@@ -333,6 +333,8 @@ open.mp releases can use `A` as the first digit.
 // Util
 
 #if !defined _console_included
+	#define _console_included
+
 	/// <summary>Prints a string to the server console (not in-game chat) and logs (server_log.txt).</summary>
 	/// <param name="string">The string to print</param>
 	/// <seealso name="printf"/>


### PR DESCRIPTION
Just to really really prevent `print` and `printf` being defined twice.