### PR TITLE
Update dependencies in pawn.lang file

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -1,5 +1,5 @@
 {
     "user": "sampctl",
     "repo": "samp-stdlib",
-    "dependencies": ["sampctl/pawn-stdlib"]
+    "dependencies": ["pawn-lang/pawn-stdlib"]
 }


### PR DESCRIPTION
I was trying to ensure a package with `sampctl/samp-stdlib` as their unique dependency. The program was redirecting good the first dependency (`sampctl/samp-stdlib` to `pawn-lang/samp-stdlib`), but then it got stuck at `sampctl/pawn-stdlib`. An easy way to fix it was putting `pawn-lang/pawn-stdlib` as the first element of the dependency list. Probably another way to fix it is updating the `pawn.json` file from `pawn-lang/samp-stdlib`. I don't know how to fix it in sampctl.

Logs from `sampctl p ensure --verbose`:

```
INFO: attempting to ensure dependency github.com/pawn-lang/samp-stdlib
INFO: github.com/pawn-lang/samp-stdlib package does not exist at C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\samp-stdlib cloning new copy
INFO: github.com/pawn-lang/samp-stdlib need to clone new copy from cache
INFO: github.com/pawn-lang/samp-stdlib ensuring dependency package from cache to C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\samp-stdlib force update: false
INFO: no repo at C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\samp-stdlib - repository does not exist cloning new copy
INFO: cloning latest copy to C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\samp-stdlib with &{C:\Users\Fede\.samp\packages\pawn-lang\samp-stdlib\default <nil>   false false 1000 0 <nil> 0}
INFO: github.com/pawn-lang/samp-stdlib updating dependency package
INFO: github.com/pawn-lang/samp-stdlib updating repository state with <nil> authentication method
INFO: github.com/pawn-lang/samp-stdlib package does not have version constraint pulling latest
INFO: Autorojo/samp_blackjack successfully ensured dependency files for github.com/pawn-lang/samp-stdlib
INFO: attempting to ensure dependency github.com/sampctl/pawn-stdlib
INFO: github.com/sampctl/pawn-stdlib package does not exist at C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\pawn-stdlib cloning new copy
INFO: github.com/sampctl/pawn-stdlib need to clone new copy from cache
INFO: github.com/sampctl/pawn-stdlib ensuring dependency package from cache to C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\pawn-stdlib force update: false
INFO: no repo at C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\pawn-stdlib - repository does not exist cloning new copy
INFO: cloning latest copy to C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\pawn-stdlib with &{C:\Users\Fede\.samp\packages\sampctl\pawn-stdlib\default <nil>   false false 1000 0 <nil> 0}
WARN: failed to ensure package github.com/sampctl/pawn-stdlib: reference not found
INFO: attempting to ensure dependency github.com/sampctl/pawn-stdlib
INFO: github.com/sampctl/pawn-stdlib package does not exist at C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\pawn-stdlib cloning new copy
INFO: github.com/sampctl/pawn-stdlib need to clone new copy from cache
INFO: github.com/sampctl/pawn-stdlib ensuring dependency package from cache to C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\pawn-stdlib force update: false
INFO: no repo at C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\pawn-stdlib - repository does not exist cloning new copy
INFO: cloning latest copy to C:\Users\Fede\Documents\github\samp-blackjack-v0.2\dependencies\pawn-stdlib with &{C:\Users\Fede\.samp\packages\sampctl\pawn-stdlib\default <nil>   false false 1000 0 <nil> 0}
WARN: failed to ensure package github.com/sampctl/pawn-stdlib: reference not found
WARN: failed to ensure package github.com/sampctl/pawn-stdlib after 2 attempts, skipping
```