### PR TITLE
Fix typo, add summary for OnScriptCash

### DIFF
--- a/a_samp.inc
+++ b/a_samp.inc
@@ -3851,7 +3851,7 @@ forward OnPlayerRequestDownload(playerid, DOWNLOAD_REQUEST:type, crc);
 forward OnPlayerWeaponShot(playerid, weaponid, BULLET_HIT_TYPE:hittype, hitid, Float:fX, Float:fY, Float:fZ);
 
 /**
- * <summary>This callback is called when a SendClientCheck request comletes</summary>
+ * <summary>This callback is called when a SendClientCheck request completes</summary>
  * <param name="playerid">The ID of the player checked</param>
  * <param name="actionid">The type of check performed</param>
  * <param name="memaddr">The address requested</param>
@@ -3861,7 +3861,7 @@ forward OnPlayerWeaponShot(playerid, weaponid, BULLET_HIT_TYPE:hittype, hitid, F
 forward OnClientCheckResponse(playerid, actionid, memaddr, retndata);
 
 /**
- * <summary>This callback is called when a SendClientCheck request comletes</summary>
+ * <summary>This callback is called when the money increases from the GTA SA scm</summary>
  * <param name="playerid">The ID of the player who got cash from the game</param>
  * <param name="amount">The amount of cash given</param>
  * <param name="source">Where the money came from</param>


### PR DESCRIPTION
The summary is according to someone quoting Kalcor message which can be found here:
https://sampforum.blast.hk/showthread.php?tid=112915&pid=483659#pid483659

It's better to provide the information based on archive forum rather than giving misinformation about `OnScriptCash` even if the callback isn't working, and also fixes #32.